### PR TITLE
expose `span_exporter()` function to build custom span processor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,9 @@ jobs:
 
     - run: cargo llvm-cov --all-features --codecov --output-path codecov.json
 
+    # rust doctests (not included in cargo llvm-cov, see https://github.com/taiki-e/cargo-llvm-cov/issues/2)
+    - run: cargo test --doc
+
     - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
       - '**'
   pull_request: {}
 
+env:
+  # avoid attempting to send logs to logfire from tests
+  LOGFIRE_SEND_TO_LOGFIRE: no
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,13 @@ repos:
     pass_filenames: false
   - id: clippy
     name: Clippy
-    entry: cargo clippy -- -D warnings
+    entry: cargo clippy --all-features -- -D warnings
     types: [rust]
     language: system
     pass_filenames: false
   - id: test
     name: Test
-    entry: cargo test
+    entry: cargo test --all-features
     types: [rust]
     language: system
     pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+- Add `span_exporter()` helper to build a span exporter directly in [#20](https://github.com/pydantic/logfire-rust/pull/20)
+- Fix `set_resource` not being called on span processors added with `with_additional_span_processor()` in [#20](https://github.com/pydantic/logfire-rust/pull/20)
+
+## [v0.1.0] (2025-03-13)
+
+Initial release.
+
+[v0.1.0]: https://github.com/pydantic/logfire-rust/commits/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ repository = "https://github.com/pydantic/logfire-rust"
 log = "0.4"
 env_filter = "0.1"
 
+# deps for grpc export
+http = { version = "1.2", optional = true }
+tonic = { version = "0.12", optional = true }
+
 rand = "0.9.0"
 
 opentelemetry = { version = "0.28", default-features = false, features = ["trace"] }
@@ -39,7 +43,7 @@ ulid = "1.2.0"
 default = ["export-http-protobuf"]
 serde = ["dep:serde"]
 # FIXME might need rustls feature on all of these?
-export-grpc = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/tls"]
+export-grpc = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/tls", "dep:http", "dep:tonic"]
 export-http-protobuf = ["opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
 export-http-json = ["opentelemetry-otlp/http-json", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
 
@@ -52,3 +56,4 @@ unwrap_used = "deny"
 # in general we lint against the pedantic group, but we will whitelist
 # certain lints which we don't want to enforce (for now)
 pedantic = { level = "deny", priority = -1 }
+implicit_hasher = "allow"

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,10 @@ impl SpanProcessor for BoxedSpanProcessor {
     fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
         self.0.shutdown()
     }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.0.set_resource(resource);
+    }
 }
 
 /// Wrapper around an `IdGenerator` to use in `id_generator`.

--- a/src/exporters.rs
+++ b/src/exporters.rs
@@ -1,0 +1,219 @@
+//! Helper functions to configure mo
+use std::collections::HashMap;
+
+use opentelemetry_otlp::{MetricExporter, Protocol};
+use opentelemetry_sdk::{metrics::exporter::PushMetricExporter, trace::SpanExporter};
+
+use crate::{
+    ConfigureError, get_optional_env,
+    internal::exporters::remove_pending::RemovePendingSpansExporter,
+};
+
+macro_rules! feature_required {
+    ($feature_name:literal, $functionality:expr, $if_enabled:expr) => {{
+        #[cfg(feature = $feature_name)]
+        {
+            let _ = $functionality; // to avoid unused code warning
+            $if_enabled
+        }
+
+        #[cfg(not(feature = $feature_name))]
+        {
+            return Err(ConfigureError::LogfireFeatureRequired {
+                feature_name: $feature_name,
+                functionality: $functionality,
+            });
+        }
+    }};
+}
+
+/// Build a [`SpanExporter`][opentelemetry::trace::SpanExporter] for passing to
+/// [`with_additional_span_processor()`][crate::LogfireConfigBuilder::with_additional_span_processor].
+///
+/// This uses `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` environment
+/// variables to determine the protocol to use (or otherwise defaults to [`Protocol::HttpBinary`]).
+///
+/// # Errors
+///
+/// Returns an error if the protocol specified by the env var is not supported or if the required feature is not enabled for
+/// the given protocol.
+///
+/// Returns an error if the endpoint is not a valid URI.
+///
+/// Returns an error if any headers are not valid HTTP headers.
+pub fn span_exporter(
+    endpoint: &str,
+    headers: Option<HashMap<String, String>>,
+) -> Result<impl SpanExporter + use<>, ConfigureError> {
+    let (source, protocol) = protocol_from_env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")?;
+
+    let builder = opentelemetry_otlp::SpanExporter::builder();
+
+    // FIXME: it would be nice to let `opentelemetry-rust` handle this; ideally we could detect if
+    // OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_TRACES_PROTOCOL is set and let the SDK
+    // make a builder. (If unset, we could supply our preferred exporter.)
+    //
+    // But at the moment otel-rust ignores these env vars; see
+    // https://github.com/open-telemetry/opentelemetry-rust/issues/1983
+    let span_exporter =
+        match protocol {
+            Protocol::Grpc => {
+                feature_required!("export-grpc", source, {
+                    use opentelemetry_otlp::WithTonicConfig;
+                    builder
+                        .with_tonic()
+                        .with_channel(
+                            tonic::transport::Channel::builder(endpoint.try_into().map_err(
+                                |e: http::uri::InvalidUri| ConfigureError::Other(e.into()),
+                            )?)
+                            .connect_lazy(),
+                        )
+                        .with_metadata(build_metadata_from_headers(headers.as_ref())?)
+                        .build()?
+                })
+            }
+            Protocol::HttpBinary => {
+                feature_required!("export-http-protobuf", source, {
+                    use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+                    builder
+                        .with_http()
+                        .with_protocol(Protocol::HttpBinary)
+                        .with_headers(headers.unwrap_or_default())
+                        .with_endpoint(format!("{endpoint}/v1/traces"))
+                        .build()?
+                })
+            }
+            Protocol::HttpJson => {
+                feature_required!("export-http-json", source, {
+                    use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+                    builder
+                        .with_http()
+                        .with_protocol(Protocol::HttpBinary)
+                        .with_headers(headers.unwrap_or_default())
+                        .with_endpoint(format!("{endpoint}/v1/traces"))
+                        .build()?
+                })
+            }
+        };
+    Ok(RemovePendingSpansExporter::new(span_exporter))
+}
+
+// TODO: make this public?
+pub(crate) fn metric_exporter(
+    endpoint: &str,
+    headers: Option<HashMap<String, String>>,
+) -> Result<impl PushMetricExporter + use<>, ConfigureError> {
+    let (source, protocol) = protocol_from_env("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")?;
+
+    let builder =
+        MetricExporter::builder().with_temporality(opentelemetry_sdk::metrics::Temporality::Delta);
+
+    // FIXME: it would be nice to let `opentelemetry-rust` handle this; ideally we could detect if
+    // OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_METRICS_PROTOCOL is set and let the SDK
+    // make a builder. (If unset, we could supply our preferred exporter.)
+    //
+    // But at the moment otel-rust ignores these env vars; see
+    // https://github.com/open-telemetry/opentelemetry-rust/issues/1983
+    match protocol {
+        Protocol::Grpc => {
+            feature_required!("export-grpc", source, {
+                use opentelemetry_otlp::WithTonicConfig;
+                Ok(builder
+                    .with_tonic()
+                    .with_channel(
+                        tonic::transport::Channel::builder(
+                            endpoint.try_into().map_err(|e: http::uri::InvalidUri| {
+                                ConfigureError::Other(e.into())
+                            })?,
+                        )
+                        .connect_lazy(),
+                    )
+                    .with_metadata(build_metadata_from_headers(headers.as_ref())?)
+                    .build()?)
+            })
+        }
+        Protocol::HttpBinary => {
+            feature_required!("export-http-protobuf", source, {
+                use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+                Ok(builder
+                    .with_http()
+                    .with_protocol(Protocol::HttpBinary)
+                    .with_headers(headers.unwrap_or_default())
+                    .with_endpoint(format!("{endpoint}/v1/metrics"))
+                    .build()?)
+            })
+        }
+        Protocol::HttpJson => {
+            feature_required!("export-http-json", source, {
+                use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+                Ok(builder
+                    .with_http()
+                    .with_protocol(Protocol::HttpBinary)
+                    .with_headers(headers.unwrap_or_default())
+                    .with_endpoint(format!("{endpoint}/v1/metrics"))
+                    .build()?)
+            })
+        }
+    }
+}
+
+#[cfg(feature = "export-grpc")]
+fn build_metadata_from_headers(
+    headers: Option<&HashMap<String, String>>,
+) -> Result<tonic::metadata::MetadataMap, ConfigureError> {
+    let Some(headers) = headers else {
+        return Ok(tonic::metadata::MetadataMap::new());
+    };
+
+    let mut header_map = http::HeaderMap::new();
+    for (key, value) in headers {
+        header_map.insert(
+            http::HeaderName::try_from(key).map_err(|e| ConfigureError::Other(e.into()))?,
+            http::HeaderValue::try_from(value).map_err(|e| ConfigureError::Other(e.into()))?,
+        );
+    }
+    Ok(tonic::metadata::MetadataMap::from_headers(header_map))
+}
+
+// current default logfire protocol is to export over HTTP in binary format
+const DEFAULT_LOGFIRE_PROTOCOL: Protocol = Protocol::HttpBinary;
+
+// standard OTLP protocol values in configuration
+const OTEL_EXPORTER_OTLP_PROTOCOL_GRPC: &str = "grpc";
+const OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF: &str = "http/protobuf";
+const OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON: &str = "http/json";
+
+/// Temporary workaround for lack of <https://github.com/open-telemetry/opentelemetry-rust/pull/2758>
+fn protocol_from_str(value: &str) -> Result<Protocol, ConfigureError> {
+    match value {
+        OTEL_EXPORTER_OTLP_PROTOCOL_GRPC => Ok(Protocol::Grpc),
+        OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_PROTOBUF => Ok(Protocol::HttpBinary),
+        OTEL_EXPORTER_OTLP_PROTOCOL_HTTP_JSON => Ok(Protocol::HttpJson),
+        _ => Err(ConfigureError::Other(
+            format!("unsupported protocol: {value}").into(),
+        )),
+    }
+}
+
+/// Get a protocol from the environment (or default value), returning a string describing the source
+/// plus the parsed protocol.
+fn protocol_from_env(data_env_var: &str) -> Result<(String, Protocol), ConfigureError> {
+    // try both data-specific env var and general protocol
+    [data_env_var, "OTEL_EXPORTER_OTLP_PROTOCOL"]
+        .into_iter()
+        .find_map(|var_name| match get_optional_env(var_name, None) {
+            Ok(Some(value)) => Some(Ok((var_name, value))),
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+        })
+        .transpose()?
+        .map_or_else(
+            || {
+                Ok((
+                    "the default logfire export protocol".to_string(),
+                    DEFAULT_LOGFIRE_PROTOCOL,
+                ))
+            },
+            |(var_name, value)| Ok((format!("`{var_name}={value}`"), protocol_from_str(&value)?)),
+        )
+}

--- a/src/internal/exporters/remove_pending.rs
+++ b/src/internal/exporters/remove_pending.rs
@@ -46,6 +46,18 @@ impl<Inner: SpanExporter> SpanExporter for RemovePendingSpansExporter<Inner> {
         spans.extend(spans_by_id.into_values());
         self.0.export(spans)
     }
+
+    fn shutdown(&mut self) -> OTelSdkResult {
+        self.0.shutdown()
+    }
+
+    fn force_flush(&mut self) -> OTelSdkResult {
+        self.0.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.0.set_resource(resource);
+    }
 }
 
 #[cfg(test)]

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -153,8 +153,8 @@ macro_rules! debug {
 ///
 /// // Typically a span will be "entered" to set the parent implicitly
 /// root_span.in_scope(|| {
-///     // This logf will be a child of root_span
-///     logfire::log!(level::INFO, "Nested log", x = 42, y = "hello");
+///     // This log will be a child of root_span
+///     logfire::log!(Level::INFO, "Nested log", x = 42, y = "hello");
 ///     // or
 ///     logfire::info!("Nested log", x = 42, y = "hello");
 ///


### PR DESCRIPTION
This PR makes the internal `span_exporter()` function public for use downstream in cases where users want to build a span exporter themselves, to set custom headers etc.

At the same time this cleans up a few bits found while working on this patch:
- Run doctests in CI
- Check all features in CI
- Fix `Resource` not being properly configured by `OTEL_SERVICE_NAME` env var etc.