### PR TITLE
support printing tracing events (to console)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ chrono = "0.4.39"
 [dev-dependencies]
 insta = "1.42.1"
 opentelemetry_sdk = { version = "0.28", default-features = false, features = ["testing"] }
+regex = "1.11.1"
 ulid = "1.2.0"
 
 [features]

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -7,6 +7,8 @@ use tracing::Subscriber;
 use tracing_opentelemetry::{OtelData, PreSampledTracer};
 use tracing_subscriber::{Layer, registry::LookupSpan};
 
+use crate::try_with_logfire_tracer;
+
 pub(crate) struct LogfireTracingLayer(pub(crate) opentelemetry_sdk::trace::Tracer);
 
 impl<S> Layer<S> for LogfireTracingLayer
@@ -98,6 +100,21 @@ where
             }
         }
     }
+
+    /// Tracing events currently are recorded as span events, so do not get printed by the span emitter.
+    ///
+    /// Instead we need to handle them here and write them to the logfire writer.
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        try_with_logfire_tracer(|tracer| {
+            if let Some(writer) = &tracer.console_writer {
+                writer.write_tracing_event(event);
+            }
+        });
+    }
 }
 
 pub(crate) fn level_to_level_number(level: tracing::Level) -> i64 {
@@ -108,5 +125,1103 @@ pub(crate) fn level_to_level_number(level: tracing::Level) -> i64 {
         tracing::Level::INFO => 9,
         tracing::Level::WARN => 13,
         tracing::Level::ERROR => 17,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time;
+    use std::sync::{Arc, Mutex};
+
+    use insta::{assert_debug_snapshot, assert_snapshot};
+    use opentelemetry_sdk::trace::{InMemorySpanExporterBuilder, SimpleSpanProcessor};
+    use regex::{Captures, Regex};
+    use tracing::{Level, level_filters::LevelFilter};
+
+    use crate::{
+        config::{AdvancedOptions, ConsoleOptions, Target},
+        set_local_logfire,
+        tests::{DeterministicExporter, DeterministicIdGenerator},
+    };
+
+    #[test]
+    fn test_tracing_bridge() {
+        let exporter = InMemorySpanExporterBuilder::new().build();
+
+        let config = crate::configure()
+            .send_to_logfire(false)
+            .with_additional_span_processor(SimpleSpanProcessor::new(Box::new(
+                DeterministicExporter::new(exporter.clone(), file!(), line!()),
+            )))
+            .install_panic_handler()
+            .with_default_level_filter(LevelFilter::TRACE)
+            .with_advanced_options(
+                AdvancedOptions::default().with_id_generator(DeterministicIdGenerator::new()),
+            );
+
+        let guard = set_local_logfire(config).unwrap();
+
+        tracing::subscriber::with_default(guard.subscriber.clone(), || {
+            let root = tracing::span!(Level::INFO, "root span").entered();
+            let _ = tracing::span!(Level::INFO, "hello world span").entered();
+            let _ = tracing::span!(Level::DEBUG, "debug span");
+            let _ = tracing::span!(parent: &root, Level::DEBUG, "debug span with explicit parent");
+            tracing::info!("hello world log");
+        });
+
+        let spans = exporter.get_finished_spans().unwrap();
+        assert_debug_snapshot!(spans, @r#"
+        [
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f1,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f0,
+                span_kind: Internal,
+                name: "root span",
+                start_time: SystemTime {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            11,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            9,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f3,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f2,
+                span_kind: Internal,
+                name: "hello world span",
+                start_time: SystemTime {
+                    tv_sec: 1,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 1,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            12,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            9,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.pending_parent_id",
+                        ),
+                        value: String(
+                            Owned(
+                                "00000000000000f0",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f2,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f0,
+                span_kind: Internal,
+                name: "hello world span",
+                start_time: SystemTime {
+                    tv_sec: 1,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 2,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            12,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            9,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "busy_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "idle_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f5,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f4,
+                span_kind: Internal,
+                name: "debug span",
+                start_time: SystemTime {
+                    tv_sec: 3,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 3,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            13,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.pending_parent_id",
+                        ),
+                        value: String(
+                            Owned(
+                                "00000000000000f0",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f4,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f0,
+                span_kind: Internal,
+                name: "debug span",
+                start_time: SystemTime {
+                    tv_sec: 3,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 4,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            13,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "busy_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "idle_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f7,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f6,
+                span_kind: Internal,
+                name: "debug span with explicit parent",
+                start_time: SystemTime {
+                    tv_sec: 5,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 5,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            14,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.pending_parent_id",
+                        ),
+                        value: String(
+                            Owned(
+                                "00000000000000f0",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f6,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f0,
+                span_kind: Internal,
+                name: "debug span with explicit parent",
+                start_time: SystemTime {
+                    tv_sec: 5,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 6,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            14,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "busy_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "idle_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f0,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 0000000000000000,
+                span_kind: Internal,
+                name: "root span",
+                start_time: SystemTime {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 7,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/bridges/tracing.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::bridges::tracing::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            11,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "bridges::tracing::tests::test_tracing_bridge",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            9,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "busy_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "idle_ns",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [
+                        Event {
+                            name: "hello world log",
+                            timestamp: SystemTime {
+                                tv_sec: 8,
+                                tv_nsec: 0,
+                            },
+                            attributes: [
+                                KeyValue {
+                                    key: Static(
+                                        "level",
+                                    ),
+                                    value: String(
+                                        Static(
+                                            "INFO",
+                                        ),
+                                    ),
+                                },
+                                KeyValue {
+                                    key: Static(
+                                        "target",
+                                    ),
+                                    value: String(
+                                        Static(
+                                            "logfire::bridges::tracing::tests",
+                                        ),
+                                    ),
+                                },
+                                KeyValue {
+                                    key: Static(
+                                        "code.filepath",
+                                    ),
+                                    value: String(
+                                        Static(
+                                            "src/bridges/tracing.rs",
+                                        ),
+                                    ),
+                                },
+                                KeyValue {
+                                    key: Static(
+                                        "code.namespace",
+                                    ),
+                                    value: String(
+                                        Static(
+                                            "logfire::bridges::tracing::tests",
+                                        ),
+                                    ),
+                                },
+                                KeyValue {
+                                    key: Static(
+                                        "code.lineno",
+                                    ),
+                                    value: I64(
+                                        169,
+                                    ),
+                                },
+                            ],
+                            dropped_attributes_count: 0,
+                        },
+                    ],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn test_tracing_bridge_console_output() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+
+        let console_options = ConsoleOptions {
+            target: Target::Pipe(output.clone()),
+            ..ConsoleOptions::default()
+        };
+
+        let config = crate::configure()
+            .send_to_logfire(false)
+            .console_options(console_options.clone())
+            .install_panic_handler()
+            .with_default_level_filter(LevelFilter::TRACE);
+
+        let guard = set_local_logfire(config).unwrap();
+
+        tracing::subscriber::with_default(guard.subscriber.clone(), || {
+            let root = tracing::span!(Level::INFO, "root span").entered();
+            let _ = tracing::span!(Level::INFO, "hello world span").entered();
+            let _ = tracing::span!(Level::DEBUG, "debug span");
+            let _ = tracing::span!(parent: &root, Level::DEBUG, "debug span with explicit parent");
+            tracing::info!("hello world log");
+        });
+
+        guard.shutdown_handler.shutdown().unwrap();
+
+        let output = output.lock().unwrap();
+        let output = std::str::from_utf8(&output).unwrap();
+
+        // Replace all timestamps in output to make them deterministic
+        let mut timestamp = chrono::DateTime::UNIX_EPOCH;
+        let re = Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z").unwrap();
+        let output = re.replace_all(output, |_: &Captures<'_>| {
+            let replaced = timestamp.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+            timestamp += time::Duration::from_micros(1);
+            replaced
+        });
+
+        assert_snapshot!(output, @r#"
+        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::bridges::tracing::tests[0m [1mroot span[0m
+        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::bridges::tracing::tests[0m [1mhello world span[0m
+        [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [2;3mlogfire::bridges::tracing::tests[0m [1mdebug span[0m
+        [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [2;3mlogfire::bridges::tracing::tests[0m [1mdebug span with explicit parent[0m
+        [2m1970-01-01T00:00:00.000004Z[0m[32m  INFO[0m [2;3mlogfire::bridges::tracing::tests[0m [1mhello world log[0m
+        "#);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ impl From<bool> for SendToLogfire {
 
 /// Options for controlling console output.
 #[expect(clippy::struct_excessive_bools)] // Config options, bools make sense here.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConsoleOptions {
     /// Whether to show colors in the console.
     pub colors: ConsoleColors,
@@ -101,7 +101,7 @@ impl Default for ConsoleOptions {
 }
 
 /// Whether to show colors in the console.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum ConsoleColors {
     /// Decide based on the terminal.
     #[default]
@@ -113,7 +113,7 @@ pub enum ConsoleColors {
 }
 
 /// Style for rendering spans in the console.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum SpanStyle {
     /// Show spans in a simple format.
     Simple,
@@ -125,7 +125,7 @@ pub enum SpanStyle {
 }
 
 /// Console target, either `stdout`, `stderr` or a custom pipe.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub enum Target {
     /// Console output will be sent to standard output.
     Stdout,

--- a/src/internal/exporters/remove_pending.rs
+++ b/src/internal/exporters/remove_pending.rs
@@ -87,6 +87,8 @@ mod tests {
             .with_additional_span_processor(
                 BatchSpanProcessor::builder(DeterministicExporter::new(
                     RemovePendingSpansExporter(exporter.clone()),
+                    file!(),
+                    line!(),
                 ))
                 .with_batch_config(
                     // Set a batch delay large enough that all spans will be in a single batch


### PR DESCRIPTION
Partially deals with #17 

`tracing::Event` by default produces a `SpanEvent`. We unpack these server-side, locally it seems desirable to show these in the console.

In a follow-up I need to make it such that top-level tracing events (i.e. not inside spans) get their own record sent directly to logfire.