### PR TITLE
fix print to console to emit spans in the right order

### DIFF
--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -92,7 +92,7 @@ impl SimpleConsoleSpanExporter {
             .unwrap_or(Cow::Borrowed("span"));
 
         // only print for pending span and logs
-        if span_type == "pending_span" {
+        if span_type == "span" {
             return Ok(());
         }
 
@@ -117,6 +117,7 @@ impl SimpleConsoleSpanExporter {
                 // Filter out known values
                 ATTRIBUTES_SPAN_TYPE_KEY
                 | "logfire.json_schema"
+                | "logfire.pending_parent_id"
                 | "code.filepath"
                 | "code.lineno"
                 | "thread.id"
@@ -218,12 +219,12 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
 
         assert_snapshot!(output, @r#"
+        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mroot span[0m
         [2m1970-01-01T00:00:01.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world span[0m
         [2m1970-01-01T00:00:03.000000Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
         [2m1970-01-01T00:00:05.000000Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [2m1970-01-01T00:00:07.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
-        [2m1970-01-01T00:00:08.000000Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:210:17, [3mbacktrace[0m=disabled backtrace
-        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mroot span[0m
+        [2m1970-01-01T00:00:08.000000Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:211:17, [3mbacktrace[0m=disabled backtrace
         "#);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1247,6 +1247,142 @@ mod tests {
             SpanData {
                 span_context: SpanContext {
                     trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f5,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f4,
+                span_kind: Internal,
+                name: "debug span",
+                start_time: SystemTime {
+                    tv_sec: 3,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 3,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/lib.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            831,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "tests::test_basic_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.msg",
+                        ),
+                        value: String(
+                            Owned(
+                                "debug span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.json_schema",
+                        ),
+                        value: String(
+                            Owned(
+                                "{\"type\":\"object\",\"properties\":{}}",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.pending_parent_id",
+                        ),
+                        value: String(
+                            Owned(
+                                "00000000000000f0",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
                     span_id: 00000000000000f4,
                     trace_flags: TraceFlags(
                         1,
@@ -1389,7 +1525,143 @@ mod tests {
             SpanData {
                 span_context: SpanContext {
                     trace_id: 000000000000000000000000000000f0,
-                    span_id: 00000000000000f5,
+                    span_id: 00000000000000f7,
+                    trace_flags: TraceFlags(
+                        1,
+                    ),
+                    is_remote: false,
+                    trace_state: TraceState(
+                        None,
+                    ),
+                },
+                parent_span_id: 00000000000000f6,
+                span_kind: Internal,
+                name: "debug span with explicit parent",
+                start_time: SystemTime {
+                    tv_sec: 5,
+                    tv_nsec: 0,
+                },
+                end_time: SystemTime {
+                    tv_sec: 5,
+                    tv_nsec: 0,
+                },
+                attributes: [
+                    KeyValue {
+                        key: Static(
+                            "code.filepath",
+                        ),
+                        value: String(
+                            Static(
+                                "src/lib.rs",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.namespace",
+                        ),
+                        value: String(
+                            Static(
+                                "logfire::tests",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "code.lineno",
+                        ),
+                        value: I64(
+                            833,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.id",
+                        ),
+                        value: I64(
+                            0,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "thread.name",
+                        ),
+                        value: String(
+                            Owned(
+                                "tests::test_basic_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.msg",
+                        ),
+                        value: String(
+                            Owned(
+                                "debug span with explicit parent",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.json_schema",
+                        ),
+                        value: String(
+                            Owned(
+                                "{\"type\":\"object\",\"properties\":{}}",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.level_num",
+                        ),
+                        value: I64(
+                            5,
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.span_type",
+                        ),
+                        value: String(
+                            Static(
+                                "pending_span",
+                            ),
+                        ),
+                    },
+                    KeyValue {
+                        key: Static(
+                            "logfire.pending_parent_id",
+                        ),
+                        value: String(
+                            Owned(
+                                "00000000000000f0",
+                            ),
+                        ),
+                    },
+                ],
+                dropped_attributes_count: 0,
+                events: SpanEvents {
+                    events: [],
+                    dropped_count: 0,
+                },
+                links: SpanLinks {
+                    links: [],
+                    dropped_count: 0,
+                },
+                status: Unset,
+                instrumentation_scope: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+            },
+            SpanData {
+                span_context: SpanContext {
+                    trace_id: 000000000000000000000000000000f0,
+                    span_id: 00000000000000f6,
                     trace_flags: TraceFlags(
                         1,
                     ),
@@ -1531,7 +1803,7 @@ mod tests {
             SpanData {
                 span_context: SpanContext {
                     trace_id: 000000000000000000000000000000f0,
-                    span_id: 00000000000000f6,
+                    span_id: 00000000000000f8,
                     trace_flags: TraceFlags(
                         1,
                     ),
@@ -1657,7 +1929,7 @@ mod tests {
             SpanData {
                 span_context: SpanContext {
                     trace_id: 000000000000000000000000000000f0,
-                    span_id: 00000000000000f7,
+                    span_id: 00000000000000f9,
                     trace_flags: TraceFlags(
                         1,
                     ),


### PR DESCRIPTION
This fixes the console exporter to print spans in the order they are entered (by the pending span), rather than the order they close.

At the same time, this tweaks the tracing bridge to always emit a pending span in a couple of cases where we might not have before, so that they can consistently be printed.