### PR TITLE
revert to only emit pending spans on first enter

### DIFF
--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -44,7 +44,7 @@ where
     /// We do this on first enter, not on creation, because some SDKs set the parent span after
     /// creation.
     ///
-    /// e.g. https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/5830c9113b0d42b72167567bf8e5f4c6b20933c8/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs#L132
+    /// e.g. <https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/5830c9113b0d42b72167567bf8e5f4c6b20933c8/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs#L132>
     fn on_enter(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
         let span = ctx.span(id).expect("span not found");
         let mut extensions = span.extensions_mut();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ use std::panic::PanicHookInfo;
 use std::sync::{Arc, Once};
 use std::{backtrace::Backtrace, env::VarError, str::FromStr, sync::OnceLock, time::Duration};
 
+use bridges::tracing::LogfireTracingPendingSpanNotSentLayer;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{
@@ -532,6 +533,7 @@ impl LogfireConfigBuilder {
 
         let subscriber = tracing_subscriber::registry()
             .with(filter)
+            .with(LogfireTracingPendingSpanNotSentLayer)
             .with(
                 tracing_opentelemetry::layer()
                     .with_error_records_to_exceptions(true)

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -468,142 +468,6 @@ fn test_basic_span() {
         SpanData {
             span_context: SpanContext {
                 trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f5,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f4,
-            span_kind: Internal,
-            name: "debug span",
-            start_time: SystemTime {
-                tv_sec: 3,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
-                tv_sec: 3,
-                tv_nsec: 0,
-            },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        16,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "debug span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        5,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.pending_parent_id",
-                    ),
-                    value: String(
-                        Owned(
-                            "00000000000000f0",
-                        ),
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
                 span_id: 00000000000000f4,
                 trace_flags: TraceFlags(
                     1,
@@ -746,143 +610,7 @@ fn test_basic_span() {
         SpanData {
             span_context: SpanContext {
                 trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f7,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f6,
-            span_kind: Internal,
-            name: "debug span with explicit parent",
-            start_time: SystemTime {
-                tv_sec: 5,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
-                tv_sec: 5,
-                tv_nsec: 0,
-            },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        17,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "debug span with explicit parent",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        5,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.pending_parent_id",
-                    ),
-                    value: String(
-                        Owned(
-                            "00000000000000f0",
-                        ),
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f6,
+                span_id: 00000000000000f5,
                 trace_flags: TraceFlags(
                     1,
                 ),
@@ -1024,7 +752,7 @@ fn test_basic_span() {
         SpanData {
             span_context: SpanContext {
                 trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f8,
+                span_id: 00000000000000f6,
                 trace_flags: TraceFlags(
                     1,
                 ),
@@ -1150,7 +878,7 @@ fn test_basic_span() {
         SpanData {
             span_context: SpanContext {
                 trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f9,
+                span_id: 00000000000000f7,
                 trace_flags: TraceFlags(
                     1,
                 ),
@@ -1244,7 +972,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        646,
+                        648,
                     ),
                 },
                 KeyValue {


### PR DESCRIPTION
It turns out that the changes in #24 to emit a pending span on enter were problematic, because some SDKs will change the trace context after creation.

... that seems like an unusual pattern. I think it'll be good enough to revert to the previous behaviour of emitting a pending span on first enter. But that means things never entered will never emit a pending span (probably fine); instead we need to add some machinery to print these to the console via a different route (if needed).