### PR TITLE
add `with_console_options` config, deprecate `console_mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Here's a simple manual tracing (aka logging) example:
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let shutdown_handler = logfire::configure()
         .install_panic_handler()
-        .send_to_logfire(true)
-        .console_mode(logfire::ConsoleMode::Fallback)
         .finish()?;
 
     logfire::info!("Hello, {name}!", name = "world");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,10 +12,7 @@ static BASIC_COUNTER: LazyLock<Counter<u64>> = LazyLock::new(|| {
 });
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let shutdown_handler = logfire::configure()
-        .install_panic_handler()
-        .console_mode(logfire::ConsoleMode::Fallback)
-        .finish()?;
+    let shutdown_handler = logfire::configure().install_panic_handler().finish()?;
 
     logfire::info!("Hello, world!");
 

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -1383,7 +1383,7 @@ mod tests {
         let handler = crate::configure()
             .local()
             .send_to_logfire(false)
-            .console_options(console_options.clone())
+            .with_console(Some(console_options.clone()))
             .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,6 @@ impl From<bool> for SendToLogfire {
 }
 
 /// Options for controlling console output.
-#[expect(clippy::struct_excessive_bools)] // Config options, bools make sense here.
 #[derive(Debug, Clone)]
 pub struct ConsoleOptions {
     /// Where to send output
@@ -89,6 +88,7 @@ pub struct ConsoleOptions {
     // show_project_link: bool,
 }
 
+#[expect(clippy::derivable_impls)] // When the other options are implemented, we will need this.
 impl Default for ConsoleOptions {
     fn default() -> Self {
         ConsoleOptions {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,6 @@ use opentelemetry_sdk::{
     metrics::reader::MetricReader,
     trace::{IdGenerator, SpanProcessor},
 };
-use tracing::Level;
 
 use crate::ConfigureError;
 
@@ -64,42 +63,71 @@ impl From<bool> for SendToLogfire {
     }
 }
 
+/// Enum to represent different states of configuration settings.
+pub enum ConfigSetting<T> {
+    /// The setting is enabled
+    Enabled(T),
+    /// The setting is disabled
+    Disabled,
+}
+
+impl<T: Default> From<bool> for ConfigSetting<T> {
+    fn from(b: bool) -> Self {
+        if b {
+            ConfigSetting::Enabled(T::default())
+        } else {
+            ConfigSetting::Disabled
+        }
+    }
+}
+
 /// Options for controlling console output.
 #[expect(clippy::struct_excessive_bools)] // Config options, bools make sense here.
 #[derive(Debug, Clone)]
 pub struct ConsoleOptions {
-    /// Whether to show colors in the console.
-    pub colors: ConsoleColors,
-    /// How spans are shown in the console.
-    pub span_style: SpanStyle,
-    /// Whether to include timestamps in the console output.
-    pub include_timestamps: bool,
-    /// Whether to include tags in the console output.
-    pub include_tags: bool,
-    /// Whether to show verbose output.
-    ///
-    /// It includes the filename, log level, and line number.
-    pub verbose: bool,
-    /// The minimum log level to show in the console.
-    pub min_log_level: Level,
-    /// Whether to print the URL of the Logfire project after initialization.
-    pub show_project_link: bool,
     /// Where to send output
-    pub target: Target,
+    pub(crate) target: Target,
+    // TODO: support the below configuration options (inherited from Python SDK)
+
+    // /// Whether to show colors in the console.
+    // colors: ConsoleColors,
+    // /// How spans are shown in the console.
+    // span_style: SpanStyle,
+    // /// Whether to include timestamps in the console output.
+    // include_timestamps: bool,
+    // /// Whether to include tags in the console output.
+    // include_tags: bool,
+    // /// Whether to show verbose output.
+    // ///
+    // /// It includes the filename, log level, and line number.
+    // verbose: bool,
+    // /// The minimum log level to show in the console.
+    // min_log_level: Level,
+    // /// Whether to print the URL of the Logfire project after initialization.
+    // show_project_link: bool,
 }
 
 impl Default for ConsoleOptions {
     fn default() -> Self {
         ConsoleOptions {
-            colors: ConsoleColors::default(),
-            span_style: SpanStyle::default(),
-            include_timestamps: true,
-            include_tags: true,
-            verbose: false,
-            min_log_level: Level::INFO,
-            show_project_link: true,
+            // colors: ConsoleColors::default(),
+            // span_style: SpanStyle::default(),
+            // include_timestamps: true,
+            // include_tags: true,
+            // verbose: false,
+            // min_log_level: Level::INFO,
+            // show_project_link: true,
             target: Target::default(),
         }
+    }
+}
+
+impl ConsoleOptions {
+    /// Set the target for console output.
+    #[must_use]
+    pub fn with_target(mut self, target: Target) -> Self {
+        self.target = target;
+        self
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,24 +63,6 @@ impl From<bool> for SendToLogfire {
     }
 }
 
-/// Enum to represent different states of configuration settings.
-pub enum ConfigSetting<T> {
-    /// The setting is enabled
-    Enabled(T),
-    /// The setting is disabled
-    Disabled,
-}
-
-impl<T: Default> From<bool> for ConfigSetting<T> {
-    fn from(b: bool) -> Self {
-        if b {
-            ConfigSetting::Enabled(T::default())
-        } else {
-            ConfigSetting::Disabled
-        }
-    }
-}
-
 /// Options for controlling console output.
 #[expect(clippy::struct_excessive_bools)] // Config options, bools make sense here.
 #[derive(Debug, Clone)]

--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -347,15 +347,12 @@ mod tests {
     fn test_print_to_console() {
         let output = Arc::new(Mutex::new(Vec::new()));
 
-        let console_options = ConsoleOptions {
-            target: Target::Pipe(output.clone()),
-            ..ConsoleOptions::default()
-        };
+        let console_options = ConsoleOptions::default().with_target(Target::Pipe(output.clone()));
 
         let handler = crate::configure()
             .local()
             .send_to_logfire(false)
-            .console_options(console_options)
+            .with_console(Some(console_options))
             .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()
@@ -387,7 +384,7 @@ mod tests {
         [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
         [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [2m1970-01-01T00:00:00.000004Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
-        [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:373:17, [3mbacktrace[0m=disabled backtrace
+        [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:370:17, [3mbacktrace[0m=disabled backtrace
         "#);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ pub enum ConsoleMode {
 }
 
 #[expect(deprecated)]
+#[expect(clippy::derivable_impls)] // default impl was generating deprecation use error?!
 impl Default for ConsoleMode {
     fn default() -> Self {
         ConsoleMode::Fallback

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::PanicHookInfo;
 use std::sync::{Arc, Once};
-use std::{backtrace::Backtrace, env::VarError, str::FromStr, sync::OnceLock, time::Duration};
+use std::{backtrace::Backtrace, env::VarError, sync::OnceLock, time::Duration};
 
 use bridges::tracing::LogfireTracingPendingSpanNotSentLayer;
 use opentelemetry::trace::TracerProvider;
@@ -190,38 +190,38 @@ pub enum ConfigureError {
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// Whether to print to the console.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[deprecated(since = "0.4.0", note = "use `ConsoleOptions` instead")]
-pub enum ConsoleMode {
-    /// Write to console if no logfire token
-    Fallback,
-    /// Force write to console
-    Force,
-}
-
 #[expect(deprecated)]
-#[expect(clippy::derivable_impls)] // default impl was generating deprecation use error?!
-impl Default for ConsoleMode {
-    fn default() -> Self {
-        ConsoleMode::Fallback
+mod deprecated {
+    use std::str::FromStr;
+
+    /// Whether to print to the console.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+    #[deprecated(since = "0.4.0", note = "use `ConsoleOptions` instead")]
+    pub enum ConsoleMode {
+        /// Write to console if no logfire token
+        #[default]
+        Fallback,
+        /// Force write to console
+        Force,
     }
-}
 
-#[expect(deprecated)]
-impl FromStr for ConsoleMode {
-    type Err = String;
+    impl FromStr for ConsoleMode {
+        type Err = String;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "fallback" => Ok(ConsoleMode::Fallback),
-            "force" => Ok(ConsoleMode::Force),
-            _ => Err(format!("invalid console mode: {s}")),
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            match s {
+                "fallback" => Ok(ConsoleMode::Fallback),
+                "force" => Ok(ConsoleMode::Force),
+                _ => Err(format!("invalid console mode: {s}")),
+            }
         }
     }
 }
+
+#[expect(deprecated)]
+use deprecated::ConsoleMode;
 
 /// Main entry point to configure logfire.
 ///

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1032,7 +1032,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        665,
+                        666,
                     ),
                 },
                 KeyValue {

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -972,7 +972,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        647,
+                        665,
                     ),
                 },
                 KeyValue {


### PR DESCRIPTION
This begins the process of making the console options more like Python; we allow either `Some(console_options)` or `None` and configure these completely independently of `send_to_logfire`.