### PR TITLE
Use `BatchStreamProcessor` for console writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1.88"
 insta = "1.42.1"
 opentelemetry_sdk = { version = "0.29", default-features = false, features = ["testing"] }
 regex = "1.11.1"
-tokio = {version = "1.44.1", features = ["test-util"] }
+tokio = { version = "1.44.1", features = ["test-util"] }
 ulid = "1.2.0"
 
 [features]

--- a/src/config.rs
+++ b/src/config.rs
@@ -400,4 +400,19 @@ mod tests {
             super::ConsoleOptions::default().with_min_log_level(tracing::Level::DEBUG);
         assert_eq!(console_options.min_log_level, tracing::Level::DEBUG);
     }
+
+    #[tokio::test]
+    async fn test_console_with_tokio_sleep() {
+        // token is invalid, so exports will fail, but it was a necessary part of reproducing the issue
+        let shutdown_handler = crate::configure()
+            .local()
+            .with_token("abc123")
+            .install_panic_handler()
+            .finish()
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        shutdown_handler.shutdown().ok();
+    }
 }

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1032,7 +1032,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        694,
+                        698,
                     ),
                 },
                 KeyValue {


### PR DESCRIPTION
- Fixes https://github.com/pydantic/logfire-rust/issues/46

This commit replaces `SimpleSpanProcessor` with `BatchSpanProcessor` for console span exporting. 

Today, the `SimpleSpanProcessor` exports spans synchronously on the current thread, which can cause deadlocks in async contexts: 

<img width="1512" alt="Screenshot 2025-05-29 at 12 33 27 PM" src="https://github.com/user-attachments/assets/d22fa79d-bdf5-4da0-bbae-27b33befa229" />


`BatchStreamProcessor` runs on a dedicated thread and avoids this issue (see https://github.com/open-telemetry/opentelemetry-rust/issues/868). It is configured here to process spans immediately (`scheduled_delay = 0`).