### PR TITLE
upgrade to opentelemetry 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ env_filter = "0.1"
 
 # deps for grpc export
 http = { version = "1.2", optional = true }
-tonic = { version = "0.12", optional = true }
+tonic = { version = "0.13", optional = true }
 
 rand = "0.9.0"
 
-opentelemetry = { version = "0.29", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.29", default-features = false, features = ["trace"] }
-opentelemetry-otlp = { version = "0.29", default-features = false, features = ["trace", "metrics"] }
+opentelemetry = { version = "0.30", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.30", default-features = false, features = ["trace", "experimental_metrics_custom_reader"] }
+opentelemetry-otlp = { version = "0.30", default-features = false, features = ["trace", "metrics"] }
 futures-util = "0.3"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-opentelemetry = "0.30"
+tracing-opentelemetry = "0.31"
 
 thiserror = "2"
 
@@ -38,7 +38,7 @@ regex = "1.11.1"
 [dev-dependencies]
 async-trait = "0.1.88"
 insta = "1.42.1"
-opentelemetry_sdk = { version = "0.29", default-features = false, features = ["testing"] }
+opentelemetry_sdk = { version = "0.30", default-features = false, features = ["testing"] }
 regex = "1.11.1"
 tokio = {version = "1.44.1", features = ["test-util"] }
 ulid = "1.2.0"
@@ -46,7 +46,6 @@ ulid = "1.2.0"
 [features]
 default = ["export-http-protobuf"]
 serde = ["dep:serde"]
-# FIXME might need rustls feature on all of these?
 export-grpc = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/tls", "dep:http", "dep:tonic"]
 export-http-protobuf = ["opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
 export-http-json = ["opentelemetry-otlp/http-json", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -311,6 +311,13 @@ impl SpanProcessor for BoxedSpanProcessor {
         self.0.shutdown()
     }
 
+    fn shutdown_with_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.0.shutdown_with_timeout(timeout)
+    }
+
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.0.set_resource(resource);
     }
@@ -354,7 +361,7 @@ impl MetricReader for BoxedMetricReader {
     fn collect(
         &self,
         rm: &mut opentelemetry_sdk::metrics::data::ResourceMetrics,
-    ) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
         self.0.collect(rm)
     }
 
@@ -364,6 +371,13 @@ impl MetricReader for BoxedMetricReader {
 
     fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
         self.0.shutdown()
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.0.shutdown_with_timeout(timeout)
     }
 
     fn temporality(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,10 +152,6 @@ pub enum ConfigureError {
     #[error("Error configuring the global logger: {0}")]
     Logging(#[from] log::SetLoggerError),
 
-    /// Error configuring the OpenTelemetry metrics.
-    #[error("Error configuring the OpenTelemetry metrics: {0}")]
-    Metrics(#[from] opentelemetry_sdk::metrics::MetricError),
-
     /// Error configuring the OpenTelemetry tracer.
     #[error("Error configuring the OpenTelemetry tracer: {0}")]
     Trace(#[from] opentelemetry_sdk::trace::TraceError),


### PR DESCRIPTION
Upgrade to the opentelemetry 0.30 ecosystem.

The `metrics` portion of the SDK has been rewritten to declare a lot of APIs as unstable and made data private. This is a bit of a pain so I've had to work around this a bit to get stuff in a state that's good enough to test for now while it's under churn.