### PR TITLE
send tracing events as logs

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_console(None)
         .finish()?;
 
-    logfire::info!("Hello, world!");
+    tracing::info!("Hello, world!");
 
     {
         let _span = logfire::span!("Asking the user their {question}", question = "age").entered();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ use opentelemetry_sdk::trace::{SdkTracerProvider, Tracer};
 use thiserror::Error;
 use tracing::Subscriber;
 use tracing::level_filters::LevelFilter;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::layer::{Layer, SubscriberExt};
 
 use crate::bridges::tracing::LogfireTracingLayer;
 use crate::config::{
@@ -577,7 +577,10 @@ impl LogfireConfigBuilder {
             .with(
                 tracing_opentelemetry::layer()
                     .with_error_records_to_exceptions(true)
-                    .with_tracer(tracer.clone()),
+                    .with_tracer(tracer.clone())
+                    .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+                        !metadata.is_event()
+                    })),
             )
             .with(LogfireTracingLayer(tracer.clone()));
 

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1034,7 +1034,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        690,
+                        693,
                     ),
                 },
                 KeyValue {


### PR DESCRIPTION
Closes #49

This unpacks tracing span events in the same way they already would be by the logfire backend, with the important difference that doing them client-side here allows them to be sent eagerly rather than waiting until the span is closed.