### PR TITLE
Support `ident` without value shorthand in macros

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -61,22 +61,41 @@ pub mod __macros_impl;
 /// // Attributes can either be a single name or a dotted.name
 /// // `dotted.name` is not available in the format string.
 /// let span = logfire::span!("Span with x = {x}, y = {y}", y = "hello", foo.bar = 42);
+///
+/// // If just an identifier is used without `= value`, it will be captured as an attribute
+/// let foo = "bar";
+/// let span = logfire::span!("Span with foo = {foo}", foo);
+///
+/// // This identifier shorthand also works for struct fields
+/// #[derive(Debug)]
+/// struct User {
+///    email: &'static str,
+///    name: &'static str,
+/// }
+///
+/// let user = User {
+///    email: "user@example.com",
+///    name: "John Doe",
+/// };
+///
+/// // NB the dotted name is not available in the format string
+/// let span = logfire::span!("Span user info", user.email, user.name);
 /// ```
 ///
 /// [attributes]: https://opentelemetry.io/docs/concepts/signals/traces/#attributes
 #[macro_export]
 macro_rules! span {
-    (parent: $parent:expr, level: $level:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!(parent: $parent, $level, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, level: $level:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::tracing_span!(parent: $parent, $level, $format, $($($path).+ $(= $value)?),*)
     };
-    (parent: $parent:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::tracing_span!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
-    (level: $level:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!($level, $format, $($($path).+ = $value),*)
+    (level: $level:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::tracing_span!($level, $format, $($($path).+ $(= $value)?),*)
     };
-    ($format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!(tracing::Level::INFO, $format, $($($path).+ = $value),*)
+    ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::tracing_span!(tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -85,11 +104,11 @@ macro_rules! span {
 /// See the [`log!`][macro@crate::log] macro for more details.
 #[macro_export]
 macro_rules! error {
-    (parent: $parent:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::ERROR, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(parent: $parent, tracing::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
     };
-    ($format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(tracing::Level::ERROR, $format, $($($path).+ = $value),*)
+    ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(tracing::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -98,11 +117,11 @@ macro_rules! error {
 /// See the [`log!`][macro@crate::log] macro for more details.
 #[macro_export]
 macro_rules! warn {
-    (parent: $parent:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::WARN, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(parent: $parent, tracing::Level::WARN, $format, $($($path).+ $(= $value)?),*)
     };
-    ($format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(tracing::Level::WARN, $format, $($($path).+ = $value),*)
+    ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(tracing::Level::WARN, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -111,11 +130,11 @@ macro_rules! warn {
 /// See the [`log!`][macro@crate::log] macro for more details.
 #[macro_export]
 macro_rules! info {
-    (parent: $parent:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
-    ($format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(tracing::Level::INFO, $format, $($($path).+ = $value),*)
+    ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -124,11 +143,11 @@ macro_rules! info {
 /// See the [`log!`][macro@crate::log] macro for more details.
 #[macro_export]
 macro_rules! debug {
-    (parent: $parent:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::DEBUG, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(parent: $parent, tracing::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
     };
-    ($format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::log!(tracing::Level::DEBUG, $format, $($($path).+ = $value),*)
+    ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::log!(tracing::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -199,15 +218,38 @@ macro_rules! debug {
 /// logfire::log!(Level::INFO, "Log with x = {x}, y = {y}", y = "hello", foo.bar = 42);
 /// // or
 /// logfire::info!("Log with x = {x}, y = {y}", y = "hello", foo.bar = 42);
+///
+/// // If just an identifier is used without `= value`, it will be captured as an attribute
+/// let foo = "bar";
+/// logfire::log!(Level::INFO, "Log with foo = {foo}", foo);
+/// // or
+/// logfire::info!("Log with foo = {foo}", foo);
+///
+/// // This identifier shorthand also works for struct fields
+/// #[derive(Debug)]
+/// struct User {
+///    email: &'static str,
+///    name: &'static str,
+/// }
+///
+/// let user = User {
+///    email: "user@example.com",
+///    name: "John Doe",
+/// };
+///
+/// // NB the dotted name is not available in the format string
+/// logfire::log!(Level::INFO, "Log user info", user.email, user.name);
+/// // or
+/// logfire::info!("Log user info", user.email, user.name);
 /// ```
 ///
 /// [attributes]: https://opentelemetry.io/docs/concepts/signals/traces/#attributes
 #[macro_export]
 macro_rules! log {
-    (parent: $parent:expr, $level:expr, $format:expr $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::log!(parent: $parent, $level, $format, $($($path).+ = $value),*)
+    (parent: $parent:expr, $level:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::log!(parent: $parent, $level, $format, $($($path).+ $(= $value)?),*)
     };
-    ($level:expr, $format:expr  $(, $($path:ident).+ = $value:expr)* $(,)?) => {
-        $crate::__macros_impl::log!(parent: &tracing::Span::current(), $level, $format, $($($path).+ = $value),*)
+    ($level:expr, $format:expr  $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
+        $crate::__macros_impl::log!(parent: &tracing::Span::current(), $level, $format, $($($path).+ $(= $value)?),*)
     };
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -220,3 +220,22 @@ pub struct DeterministicResourceMetrics {
     resource: Resource,
     scope_metrics: Vec<DeterministicScopeMetrics>,
 }
+
+/// Find a span by name in a slice of SpanData.
+pub fn find_span<'a>(
+    spans: &'a [opentelemetry_sdk::trace::SpanData],
+    name: &str,
+) -> &'a opentelemetry_sdk::trace::SpanData {
+    spans.iter().find(|s| s.name == name).expect("span present")
+}
+
+/// Find an attribute by key in a span's attributes, panicking if not found.
+pub fn find_attr<'a>(
+    span: &'a opentelemetry_sdk::trace::SpanData,
+    key: &str,
+) -> &'a opentelemetry::KeyValue {
+    span.attributes
+        .iter()
+        .find(|kv| kv.key.as_str() == key)
+        .unwrap_or_else(|| panic!("attribute '{}' not found in span '{}'", key, span.name))
+}

--- a/tests/test_log_attributes.rs
+++ b/tests/test_log_attributes.rs
@@ -1,0 +1,148 @@
+//! Tests for logfire::log! macro attribute forms.
+
+use logfire::log;
+use opentelemetry_sdk::trace::InMemorySpanExporterBuilder;
+
+#[path = "../src/test_utils.rs"]
+mod test_utils;
+
+use test_utils::{find_attr, find_span};
+use tracing::Level;
+
+#[test]
+fn test_span_macro_attributes() {
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let handler = logfire::configure()
+        .local()
+        .send_to_logfire(false)
+        .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
+            exporter.clone(),
+        ))
+        .finish()
+        .unwrap();
+    let guard = logfire::set_local_logfire(handler);
+
+    tracing::subscriber::with_default(guard.subscriber(), || {
+        let _ = log!(Level::INFO, "string_attr_log", foo = "bar");
+        let _ = log!(Level::INFO, "int_attr_log", num = 42);
+        let _ = log!(Level::INFO, "bool_attr_log", flag = true);
+        let _ = log!(Level::INFO, "dotted_attr_log", dotted.key = "value");
+        let _ = log!(
+            Level::INFO,
+            "multi_attr_log",
+            a = 1,
+            b = "two",
+            c = false,
+            d.e = 3
+        );
+    });
+    let spans = exporter.get_finished_spans().unwrap();
+
+    // String attribute
+    let span = find_span(&spans, "string_attr_log");
+    let kv = find_attr(span, "foo");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "bar"));
+
+    // Integer attribute
+    let span = find_span(&spans, "int_attr_log");
+    let kv = find_attr(span, "num");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 42));
+
+    // Boolean attribute
+    let span = find_span(&spans, "bool_attr_log");
+    let kv = find_attr(span, "flag");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if *v));
+
+    // Dotted key attribute
+    let span = find_span(&spans, "dotted_attr_log");
+    let kv = find_attr(span, "dotted.key");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "value"));
+
+    // Multiple attributes
+    let span = find_span(&spans, "multi_attr_log");
+    let kv = find_attr(span, "a");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 1));
+    let kv = find_attr(span, "b");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "two"));
+    let kv = find_attr(span, "c");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if !*v));
+    let kv = find_attr(span, "d.e");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 3));
+}
+
+#[test]
+fn test_span_macro_shorthand_ident() {
+    #[derive(Debug)]
+    struct Dotted {
+        key: &'static str,
+    }
+    #[derive(Debug)]
+    struct Multi {
+        a: i64,
+        b: &'static str,
+        c: bool,
+        d_e: i64,
+    }
+
+    let dotted = Dotted { key: "value" };
+    let int_val = 42;
+    let bool_val = true;
+    let multi = Multi {
+        a: 1,
+        b: "two",
+        c: false,
+        d_e: 3,
+    };
+
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let handler = logfire::configure()
+        .local()
+        .send_to_logfire(false)
+        .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
+            exporter.clone(),
+        ))
+        .finish()
+        .unwrap();
+    let guard = logfire::set_local_logfire(handler);
+    tracing::subscriber::with_default(guard.subscriber(), || {
+        let _ = log!(Level::INFO, "dotted_attr_log", dotted.key);
+        let _ = log!(Level::INFO, "int_attr_log", int_val);
+        let _ = log!(Level::INFO, "bool_attr_log", bool_val);
+        let _ = log!(
+            Level::INFO,
+            "multi_attr_log",
+            multi.a,
+            multi.b,
+            multi.c,
+            multi.d_e
+        );
+    });
+
+    let spans = exporter.get_finished_spans().unwrap();
+
+    // Dotted key attribute
+    let span = find_span(&spans, "dotted_attr_log");
+    let kv = find_attr(span, "dotted.key");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "value"));
+
+    // Int attribute
+    let span = find_span(&spans, "int_attr_log");
+    let kv = find_attr(span, "int_val");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 42));
+
+    // Bool attribute
+    let span = find_span(&spans, "bool_attr_log");
+    let kv = find_attr(span, "bool_val");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if *v));
+
+    // Multi attributes
+    let span = find_span(&spans, "multi_attr_log");
+    let kv = find_attr(span, "multi.a");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 1));
+    let kv = find_attr(span, "multi.b");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "two"));
+    let kv = find_attr(span, "multi.c");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if !*v));
+    let kv = find_attr(span, "multi.d_e");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 3));
+}

--- a/tests/test_span_attributes.rs
+++ b/tests/test_span_attributes.rs
@@ -1,0 +1,133 @@
+//! Tests for logfire::span! macro attribute forms.
+
+use logfire::span;
+use opentelemetry_sdk::trace::InMemorySpanExporterBuilder;
+
+#[path = "../src/test_utils.rs"]
+mod test_utils;
+
+use test_utils::{find_attr, find_span};
+
+#[test]
+fn test_span_macro_attributes() {
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let handler = logfire::configure()
+        .local()
+        .send_to_logfire(false)
+        .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
+            exporter.clone(),
+        ))
+        .finish()
+        .unwrap();
+    let guard = logfire::set_local_logfire(handler);
+
+    tracing::subscriber::with_default(guard.subscriber(), || {
+        let _ = span!("string_attr_span", foo = "bar");
+        let _ = span!("int_attr_span", num = 42);
+        let _ = span!("bool_attr_span", flag = true);
+        let _ = span!("dotted_attr_span", dotted.key = "value");
+        let _ = span!("multi_attr_span", a = 1, b = "two", c = false, d.e = 3);
+    });
+    let spans = exporter.get_finished_spans().unwrap();
+
+    // String attribute
+    let span = find_span(&spans, "string_attr_span");
+    let kv = find_attr(span, "foo");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "bar"));
+
+    // Integer attribute
+    let span = find_span(&spans, "int_attr_span");
+    let kv = find_attr(span, "num");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 42));
+
+    // Boolean attribute
+    let span = find_span(&spans, "bool_attr_span");
+    let kv = find_attr(span, "flag");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if *v));
+
+    // Dotted key attribute
+    let span = find_span(&spans, "dotted_attr_span");
+    let kv = find_attr(span, "dotted.key");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "value"));
+
+    // Multiple attributes
+    let span = find_span(&spans, "multi_attr_span");
+    let kv = find_attr(span, "a");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 1));
+    let kv = find_attr(span, "b");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "two"));
+    let kv = find_attr(span, "c");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if !*v));
+    let kv = find_attr(span, "d.e");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 3));
+}
+
+#[test]
+fn test_span_macro_shorthand_ident() {
+    #[derive(Debug)]
+    struct Dotted {
+        key: &'static str,
+    }
+    #[derive(Debug)]
+    struct Multi {
+        a: i64,
+        b: &'static str,
+        c: bool,
+        d_e: i64,
+    }
+
+    let dotted = Dotted { key: "value" };
+    let int_val = 42;
+    let bool_val = true;
+    let multi = Multi {
+        a: 1,
+        b: "two",
+        c: false,
+        d_e: 3,
+    };
+
+    let exporter = InMemorySpanExporterBuilder::new().build();
+    let handler = logfire::configure()
+        .local()
+        .send_to_logfire(false)
+        .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
+            exporter.clone(),
+        ))
+        .finish()
+        .unwrap();
+    let guard = logfire::set_local_logfire(handler);
+    tracing::subscriber::with_default(guard.subscriber(), || {
+        let _ = span!("dotted_attr_span", dotted.key);
+        let _ = span!("int_attr_span", int_val);
+        let _ = span!("bool_attr_span", bool_val);
+        let _ = span!("multi_attr_span", multi.a, multi.b, multi.c, multi.d_e);
+    });
+
+    let spans = exporter.get_finished_spans().unwrap();
+
+    // Dotted key attribute
+    let span = find_span(&spans, "dotted_attr_span");
+    let kv = find_attr(span, "dotted.key");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "value"));
+
+    // Int attribute
+    let span = find_span(&spans, "int_attr_span");
+    let kv = find_attr(span, "int_val");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 42));
+
+    // Bool attribute
+    let span = find_span(&spans, "bool_attr_span");
+    let kv = find_attr(span, "bool_val");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if *v));
+
+    // Multi attributes
+    let span = find_span(&spans, "multi_attr_span");
+    let kv = find_attr(span, "multi.a");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 1));
+    let kv = find_attr(span, "multi.b");
+    assert!(matches!(&kv.value, opentelemetry::Value::String(s) if s.as_str() == "two"));
+    let kv = find_attr(span, "multi.c");
+    assert!(matches!(&kv.value, opentelemetry::Value::Bool(v) if !*v));
+    let kv = find_attr(span, "multi.d_e");
+    assert!(matches!(&kv.value, opentelemetry::Value::I64(v) if *v == 3));
+}


### PR DESCRIPTION
Closes #55

I added new test files to specifically focus on the attribute values recorded, to test this functionality without lots of bloat.