### PR TITLE
fix location of panic messages

### DIFF
--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -248,7 +248,7 @@ mod tests {
         [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
         [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [2m1970-01-01T00:00:00.000004Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
-        [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:234:17, [3mbacktrace[0m=disabled backtrace
+        [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
         ");
     }
 
@@ -296,7 +296,7 @@ mod tests {
         [34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
         [34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
-        [31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:282:17, [3mbacktrace[0m=disabled backtrace
+        [31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
         ");
     }
 
@@ -341,7 +341,7 @@ mod tests {
         [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mroot span[0m
         [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world span[0m
         [2m1970-01-01T00:00:00.000002Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
-        [2m1970-01-01T00:00:00.000003Z[0m[31m ERROR[0m [2;3mlogfire[0m [1mpanic: oh no![0m [3mlocation[0m=src/internal/exporters/console.rs:329:17, [3mbacktrace[0m=disabled backtrace
+        [2m1970-01-01T00:00:00.000003Z[0m[31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
         ");
     }
 

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1147,6 +1147,24 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
+                        "thread.id",
+                    ),
+                    value: I64(
+                        0,
+                    ),
+                },
+                KeyValue {
+                    key: Static(
+                        "thread.name",
+                    ),
+                    value: String(
+                        Owned(
+                            "test_basic_span",
+                        ),
+                    ),
+                },
+                KeyValue {
+                    key: Static(
                         "code.filepath",
                     ),
                     value: String(
@@ -1170,24 +1188,6 @@ fn test_basic_span() {
                     value: String(
                         Static(
                             "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
                         ),
                     ),
                 },
@@ -1223,7 +1223,7 @@ fn test_basic_span() {
             },
             parent_span_id: 00000000000000f0,
             span_kind: Internal,
-            name: "panic: {message}",
+            name: "panic",
             start_time: SystemTime {
                 tv_sec: 8,
                 tv_nsec: 0,
@@ -1233,16 +1233,6 @@ fn test_basic_span() {
                 tv_nsec: 0,
             },
             attributes: [
-                KeyValue {
-                    key: Static(
-                        "location",
-                    ),
-                    value: String(
-                        Owned(
-                            "tests/test_basic_exports.rs:58:13",
-                        ),
-                    ),
-                },
                 KeyValue {
                     key: Static(
                         "backtrace",
@@ -1287,35 +1277,7 @@ fn test_basic_span() {
                     ),
                     value: String(
                         Static(
-                            "{\"type\":\"object\",\"properties\":{\"location\":{},\"backtrace\":{}}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "src/lib.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        642,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "logfire",
+                            "{\"type\":\"object\",\"properties\":{\"backtrace\":{}}}",
                         ),
                     ),
                 },
@@ -1335,6 +1297,24 @@ fn test_basic_span() {
                         Owned(
                             "test_basic_span",
                         ),
+                    ),
+                },
+                KeyValue {
+                    key: Static(
+                        "code.filepath",
+                    ),
+                    value: String(
+                        Owned(
+                            "tests/test_basic_exports.rs",
+                        ),
+                    ),
+                },
+                KeyValue {
+                    key: Static(
+                        "code.lineno",
+                    ),
+                    value: I64(
+                        19,
                     ),
                 },
             ],


### PR DESCRIPTION
While editing docs (or anything else) I keep having the coupling of the panic location to the current implementation in `lib.rs` be a pain; it needed fixing anyway so here's a 10-minute patch to correct it.