### PR TITLE
send `log` bridge data over logs stream

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -1,16 +1,16 @@
-use std::sync::OnceLock;
+use std::{borrow::Cow, sync::OnceLock};
 
 use log::{LevelFilter, Metadata, Record};
-use opentelemetry::{KeyValue, global::ObjectSafeSpan, trace::Tracer};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::internal::logfire_tracer::LogfireTracer;
 
 pub(crate) struct LogfireLogger {
-    tracer: opentelemetry_sdk::trace::Tracer,
+    tracer: LogfireTracer,
     filter: env_filter::Filter,
 }
 
 impl LogfireLogger {
-    pub(crate) fn init(tracer: opentelemetry_sdk::trace::Tracer) -> &'static Self {
+    pub(crate) fn init(tracer: LogfireTracer) -> &'static Self {
         static LOGGER: OnceLock<LogfireLogger> = OnceLock::new();
         LOGGER.get_or_init(move || {
             let mut filter_builder = env_filter::Builder::new();
@@ -39,90 +39,1152 @@ impl log::Log for LogfireLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            self.tracer
-                .span_builder("log message")
-                .with_attributes([
-                    KeyValue::new("logfire.msg", record.args().to_string()),
-                    KeyValue::new("logfire.level_num", level_to_level_number(record.level())),
-                    KeyValue::new("logfire.span_type", "log"),
-                ])
-                .start_with_context(&self.tracer, &tracing::Span::current().context())
-                .end();
+            self.tracer.export_log(
+                "log message",
+                &tracing::Span::current(),
+                record.args().to_string(),
+                level_to_severity(record.level()),
+                "{}",
+                record.file().map(|s| Cow::Owned(s.to_string())),
+                record.line(),
+                record.module_path().map(|s| Cow::Owned(s.to_string())),
+                [],
+            );
         }
     }
 
     fn flush(&self) {}
 }
 
-fn level_to_level_number(level: log::Level) -> i64 {
+fn level_to_severity(level: log::Level) -> opentelemetry::logs::Severity {
     match level {
-        log::Level::Trace => 1,
-        log::Level::Debug => 5,
-        log::Level::Info => 9,
-        log::Level::Warn => 13,
-        log::Level::Error => 17,
+        log::Level::Error => opentelemetry::logs::Severity::Error,
+        log::Level::Warn => opentelemetry::logs::Severity::Warn,
+        log::Level::Info => opentelemetry::logs::Severity::Info,
+        log::Level::Debug => opentelemetry::logs::Severity::Debug,
+        log::Level::Trace => opentelemetry::logs::Severity::Trace,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use log::Log;
-    use opentelemetry::trace::TracerProvider as _;
-    use opentelemetry_sdk::trace::SdkTracerProvider;
-    use opentelemetry_sdk::trace::SpanData;
-    use opentelemetry_sdk::trace::in_memory_exporter::InMemorySpanExporterBuilder;
-    use tracing_subscriber::layer::SubscriberExt;
+    use std::sync::{Arc, Mutex};
+
+    use insta::{assert_debug_snapshot, assert_snapshot};
+    use opentelemetry_sdk::logs::in_memory_exporter::InMemoryLogExporter;
+    use tracing::level_filters::LevelFilter as TracingLevelFilter;
+
+    use crate::{
+        bridges::log::LogfireLogger,
+        config::{AdvancedOptions, ConsoleOptions, Target},
+        set_local_logfire,
+        test_utils::{
+            DeterministicIdGenerator, make_deterministic_logs, remap_timestamps_in_console_output,
+        },
+    };
 
     #[test]
-    fn test_logfire_logger() {
-        let exporter = InMemorySpanExporterBuilder::new().build();
-        let provider = SdkTracerProvider::builder()
-            .with_simple_exporter(exporter.clone())
-            .build();
-        let tracer = provider.tracer("test");
-        let logger = LogfireLogger::init(tracer.clone());
-        tracing::subscriber::with_default(
-            tracing_subscriber::registry()
-                .with(tracing_opentelemetry::layer().with_tracer(tracer.clone())),
-            || {
-                let record = Record::builder()
-                    .args(format_args!("test message"))
-                    .level(log::Level::Info)
-                    .target("test")
-                    .module_path(Some("test"))
-                    .file(Some("test.rs"))
-                    .line(Some(42))
-                    .build();
+    fn test_log_bridge() {
+        const TEST_FILE: &str = file!();
+        const TEST_LINE: u32 = line!();
 
-                let _ = crate::configure()
-                    .send_to_logfire(crate::SendToLogfire::No)
-                    .finish();
-                crate::span!("root span",).in_scope(|| logger.log(&record));
+        let log_exporter = InMemoryLogExporter::default();
+
+        let handler = crate::configure()
+            .local()
+            .send_to_logfire(false)
+            .install_panic_handler()
+            .with_default_level_filter(TracingLevelFilter::TRACE)
+            .with_advanced_options(
+                AdvancedOptions::default()
+                    .with_id_generator(DeterministicIdGenerator::new())
+                    .with_log_processor(opentelemetry_sdk::logs::SimpleLogProcessor::new(
+                        log_exporter.clone(),
+                    )),
+            )
+            .finish()
+            .unwrap();
+
+        let lf_logger = LogfireLogger {
+            tracer: handler.tracer.clone(),
+            filter: env_filter::Builder::new().parse("trace").build(),
+        };
+
+        log::set_max_level(log::LevelFilter::Trace);
+        let guard = set_local_logfire(handler);
+
+        tracing::subscriber::with_default(guard.subscriber().clone(), || {
+            log::info!(logger: lf_logger, "root event");
+            log::info!(logger: lf_logger, target: "custom_target", "root event with target");
+
+            let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
+            log::info!(logger: lf_logger, "hello world log");
+            log::warn!(logger: lf_logger, "warning log");
+            log::error!(logger: lf_logger, "error log");
+            log::debug!(logger: lf_logger, "debug log");
+            log::trace!(logger: lf_logger, "trace log");
+        });
+
+        let logs = log_exporter.get_emitted_logs().unwrap();
+        let logs = make_deterministic_logs(logs, TEST_FILE, TEST_LINE);
+        assert_debug_snapshot!(logs, @r#"
+        [
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 0,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 0,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 00000000000000000000000000000000,
+                            span_id: 0000000000000000,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    0,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "INFO",
+                    ),
+                    severity_number: Some(
+                        Info,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "root event",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        28,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "root event",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
             },
-        );
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 1,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 1,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 00000000000000000000000000000000,
+                            span_id: 0000000000000000,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    0,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "INFO",
+                    ),
+                    severity_number: Some(
+                        Info,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "root event with target",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        29,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "root event with target",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 2,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 2,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 000000000000000000000000000000f0,
+                            span_id: 00000000000000f0,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "INFO",
+                    ),
+                    severity_number: Some(
+                        Info,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "hello world log",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        32,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "hello world log",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 3,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 3,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 000000000000000000000000000000f0,
+                            span_id: 00000000000000f0,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "WARN",
+                    ),
+                    severity_number: Some(
+                        Warn,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "warning log",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        33,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "warning log",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 4,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 4,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 000000000000000000000000000000f0,
+                            span_id: 00000000000000f0,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "ERROR",
+                    ),
+                    severity_number: Some(
+                        Error,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "error log",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        34,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "error log",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 5,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 5,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 000000000000000000000000000000f0,
+                            span_id: 00000000000000f0,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "DEBUG",
+                    ),
+                    severity_number: Some(
+                        Debug,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "debug log",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        35,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "debug log",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+            LogDataWithResource {
+                record: SdkLogRecord {
+                    event_name: None,
+                    target: None,
+                    timestamp: Some(
+                        SystemTime {
+                            tv_sec: 6,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    observed_timestamp: Some(
+                        SystemTime {
+                            tv_sec: 6,
+                            tv_nsec: 0,
+                        },
+                    ),
+                    trace_context: Some(
+                        TraceContext {
+                            trace_id: 000000000000000000000000000000f0,
+                            span_id: 00000000000000f0,
+                            trace_flags: Some(
+                                TraceFlags(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    severity_text: Some(
+                        "TRACE",
+                    ),
+                    severity_number: Some(
+                        Trace,
+                    ),
+                    body: Some(
+                        String(
+                            Owned(
+                                "trace log",
+                            ),
+                        ),
+                    ),
+                    attributes: GrowableArray {
+                        inline: [
+                            Some(
+                                (
+                                    Static(
+                                        "code.filepath",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "src/bridges/log.rs",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.lineno",
+                                    ),
+                                    Int(
+                                        36,
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "code.namespace",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "logfire::bridges::log::tests",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.json_schema",
+                                    ),
+                                    String(
+                                        Static(
+                                            "{}",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Some(
+                                (
+                                    Static(
+                                        "logfire.msg",
+                                    ),
+                                    String(
+                                        Owned(
+                                            "trace log",
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ],
+                        overflow: Some(
+                            [
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.id",
+                                        ),
+                                        Int(
+                                            0,
+                                        ),
+                                    ),
+                                ),
+                                Some(
+                                    (
+                                        Static(
+                                            "thread.name",
+                                        ),
+                                        String(
+                                            Owned(
+                                                "bridges::log::tests::test_log_bridge",
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ],
+                        ),
+                        count: 5,
+                    },
+                },
+                instrumentation: InstrumentationScope {
+                    name: "logfire",
+                    version: None,
+                    schema_url: None,
+                    attributes: [],
+                },
+                resource: Resource {
+                    inner: ResourceInner {
+                        attrs: {},
+                        schema_url: None,
+                    },
+                },
+            },
+        ]
+        "#);
+    }
 
-        let mut spans = exporter.get_finished_spans().unwrap();
-        assert!(spans.len() == 2);
+    #[test]
+    fn test_log_bridge_console_output() {
+        let output = Arc::new(Mutex::new(Vec::new()));
 
-        let root_span: SpanData = spans.pop().unwrap();
-        let root_span_id = root_span.span_context.span_id();
-        let trace_id = root_span.span_context.trace_id();
+        let console_options = ConsoleOptions {
+            target: Target::Pipe(output.clone()),
+            ..ConsoleOptions::default().with_min_log_level(tracing::Level::TRACE)
+        };
 
-        let mut span: SpanData = spans.pop().unwrap();
-        span.attributes.sort_by_key(|k| k.key.clone());
-        assert_eq!(span.name, "log message");
-        assert_eq!(span.attributes.len(), 3);
-        assert_eq!(span.span_context.trace_id(), trace_id);
-        assert_eq!(span.parent_span_id, root_span_id);
-        assert_eq!(span.attributes[0], KeyValue::new("logfire.level_num", 9i64));
-        assert_eq!(
-            span.attributes[1],
-            KeyValue::new("logfire.msg", "test message")
-        );
-        assert_eq!(
-            span.attributes[2],
-            KeyValue::new("logfire.span_type", "log")
-        );
+        let handler = crate::configure()
+            .local()
+            .send_to_logfire(false)
+            .with_console(Some(console_options.clone()))
+            .install_panic_handler()
+            .with_default_level_filter(TracingLevelFilter::TRACE)
+            .finish()
+            .unwrap();
+
+        let lf_logger = LogfireLogger {
+            tracer: handler.tracer.clone(),
+            filter: env_filter::Builder::new().parse("trace").build(),
+        };
+
+        log::set_max_level(log::LevelFilter::Trace);
+        let guard = crate::set_local_logfire(handler);
+
+        tracing::subscriber::with_default(guard.subscriber().clone(), || {
+            log::info!(logger: lf_logger, "root event");
+            log::info!(logger: lf_logger, target: "custom_target", "root event with target");
+
+            let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
+            log::info!(logger: lf_logger, "hello world log");
+            log::warn!(logger: lf_logger, "warning log");
+            log::error!(logger: lf_logger, "error log");
+            log::trace!(logger: lf_logger, "trace log");
+        });
+
+        guard.shutdown_handler.shutdown().unwrap();
+
+        let output = output.lock().unwrap();
+        let output = std::str::from_utf8(&output).unwrap();
+        let output = remap_timestamps_in_console_output(output);
+
+        assert_snapshot!(output, @r"
+        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::bridges::log::tests[0m [1mroot event[0m
+        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::bridges::log::tests[0m [1mroot event with target[0m
+        [2m1970-01-01T00:00:00.000002Z[0m[32m  INFO[0m [2;3mlogfire::bridges::log::tests[0m [1mroot span[0m
+        [2m1970-01-01T00:00:00.000003Z[0m[32m  INFO[0m [2;3mlogfire::bridges::log::tests[0m [1mhello world log[0m
+        [2m1970-01-01T00:00:00.000004Z[0m[33m  WARN[0m [2;3mlogfire::bridges::log::tests[0m [1mwarning log[0m
+        [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [2;3mlogfire::bridges::log::tests[0m [1merror log[0m
+        [2m1970-01-01T00:00:00.000006Z[0m[35m TRACE[0m [2;3mlogfire::bridges::log::tests[0m [1mtrace log[0m
+        ");
     }
 }

--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -297,7 +297,6 @@ impl ConsoleWriter {
 
     fn log_to_writer<W: io::Write>(&self, log_record: &SdkLogRecord, w: &mut W) -> io::Result<()> {
         let mut msg = None;
-        let mut level = None;
         let mut target = None;
 
         let mut fields = Vec::new();
@@ -307,14 +306,6 @@ impl ConsoleWriter {
                 "logfire.msg" => {
                     if let opentelemetry::logs::AnyValue::String(s) = value {
                         msg = Some(s.as_str());
-                    }
-                }
-                "logfire.level_num" => {
-                    if let opentelemetry::logs::AnyValue::Int(level_num) = value {
-                        if *level_num < level_to_level_number(self.options.min_log_level) {
-                            return Ok(());
-                        }
-                        level = Some(*level_num);
                     }
                 }
                 "code.namespace" => {
@@ -355,8 +346,8 @@ impl ConsoleWriter {
             }
         }
 
-        if let Some(level) = level {
-            level_int_to_text(level, w)?;
+        if let Some(level) = log_record.severity_number() {
+            level_int_to_text(level as i64, w)?;
         }
 
         if let Some(target) = target {

--- a/src/internal/logfire_tracer.rs
+++ b/src/internal/logfire_tracer.rs
@@ -1,0 +1,154 @@
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    sync::{Arc, OnceLock},
+    time::SystemTime,
+};
+
+use opentelemetry::{
+    Array, Value,
+    logs::{AnyValue, LogRecord, Logger, Severity},
+    trace::TraceContextExt,
+};
+use opentelemetry_sdk::{logs::SdkLogger, trace::Tracer};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::__macros_impl::LogfireValue;
+
+#[derive(Clone)]
+pub(crate) struct LogfireTracer {
+    pub(crate) inner: Tracer,
+    pub(crate) logger: Arc<SdkLogger>,
+    pub(crate) handle_panics: bool,
+}
+
+// Global tracer configured in `logfire::configure()`
+pub(crate) static GLOBAL_TRACER: OnceLock<LogfireTracer> = OnceLock::new();
+
+thread_local! {
+    pub(crate) static LOCAL_TRACER: RefCell<Option<LogfireTracer>> = const { RefCell::new(None) };
+}
+
+impl LogfireTracer {
+    pub(crate) fn try_with<R>(f: impl FnOnce(&LogfireTracer) -> R) -> Option<R> {
+        let mut f = Some(f);
+        if let Some(result) = LOCAL_TRACER
+            .try_with(|local_logfire| {
+                local_logfire
+                    .borrow()
+                    .as_ref()
+                    .map(|tracer| f.take().expect("not called")(tracer))
+            })
+            .ok()
+            .flatten()
+        {
+            return Some(result);
+        }
+
+        GLOBAL_TRACER.get().map(f.expect("local tls not used"))
+    }
+
+    #[expect(clippy::too_many_arguments)] // FIXME probably can group these
+    pub fn export_log(
+        &self,
+        name: &'static str,
+        parent_span: &tracing::Span,
+        message: String,
+        severity: Severity,
+        schema: &'static str,
+        file: Option<Cow<'static, str>>,
+        line: Option<u32>,
+        module_path: Option<Cow<'static, str>>,
+        args: impl IntoIterator<Item = LogfireValue>,
+    ) {
+        thread_local! {
+            static THREAD_ID: i64 = {
+                // thread ID doesn't expose inner value, so we have to parse it out :(
+                // (tracing-opentelemetry does the same)
+                // format is ThreadId(N)
+                let s = format!("{:?}", std::thread::current().id());
+                let data = s.split_at(9).1;
+                let data = data.split_at(data.len() - 1).0;
+                data.parse().expect("should always be a valid number")
+            }
+        }
+
+        let mut null_args: Vec<AnyValue> = Vec::new();
+
+        // Create and emit a log record instead of a span
+        let mut log_record = self.logger.create_log_record();
+
+        let ts = SystemTime::now();
+
+        log_record.set_event_name(name);
+        log_record.set_timestamp(ts);
+        log_record.set_observed_timestamp(ts);
+        log_record.set_body(message.clone().into());
+        log_record.set_severity_text(severity.name());
+        log_record.set_severity_number(severity);
+
+        for arg in args {
+            if let Some(value) = arg.value {
+                let any_value = match value {
+                    Value::Bool(b) => AnyValue::Boolean(b),
+                    Value::I64(i) => AnyValue::Int(i),
+                    Value::F64(f) => AnyValue::Double(f),
+                    Value::String(string_value) => AnyValue::String(string_value),
+                    Value::Array(Array::Bool(b)) => {
+                        AnyValue::ListAny(Box::new(b.into_iter().map(AnyValue::Boolean).collect()))
+                    }
+                    Value::Array(Array::I64(i)) => {
+                        AnyValue::ListAny(Box::new(i.into_iter().map(AnyValue::Int).collect()))
+                    }
+                    Value::Array(Array::F64(f)) => {
+                        AnyValue::ListAny(Box::new(f.into_iter().map(AnyValue::Double).collect()))
+                    }
+                    Value::Array(Array::String(s)) => {
+                        AnyValue::ListAny(Box::new(s.into_iter().map(AnyValue::String).collect()))
+                    }
+                    _ => AnyValue::String(format!("{value:?}").into()),
+                };
+                log_record.add_attribute(arg.name, any_value);
+            } else {
+                null_args.push(arg.name.as_str().to_owned().into());
+            }
+        }
+
+        log_record.add_attribute("logfire.msg", message);
+        log_record.add_attribute("logfire.json_schema", schema);
+        log_record.add_attribute("thread.id", THREAD_ID.with(|id| *id));
+
+        // Add thread name if available
+        if let Some(thread_name) = std::thread::current().name() {
+            log_record.add_attribute("thread.name", thread_name.to_owned());
+        }
+
+        if let Some(file) = file {
+            log_record.add_attribute("code.filepath", file);
+        }
+
+        if let Some(line) = line {
+            log_record.add_attribute("code.lineno", i64::from(line));
+        }
+
+        if let Some(module_path) = module_path {
+            log_record.add_attribute("code.namespace", module_path);
+        }
+
+        if !null_args.is_empty() {
+            log_record.add_attribute("logfire.null_args", AnyValue::ListAny(Box::new(null_args)));
+        }
+
+        // Get trace context from parent span
+        let context = parent_span.context();
+        let span = context.span();
+        let span_context = span.span_context();
+        log_record.set_trace_context(
+            span_context.trace_id(),
+            span_context.span_id(),
+            Some(span_context.trace_flags()),
+        );
+
+        self.logger.emit(log_record);
+    }
+}

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod constants;
 pub(crate) mod exporters;
+pub(crate) mod logfire_tracer;
 pub(crate) mod span_data_ext;

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1338,16 +1338,6 @@ fn test_basic_span() {
                             Some(
                                 (
                                     Static(
-                                        "logfire.level_num",
-                                    ),
-                                    Int(
-                                        9,
-                                    ),
-                                ),
-                            ),
-                            Some(
-                                (
-                                    Static(
                                         "logfire.msg",
                                     ),
                                     String(
@@ -1488,28 +1478,18 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "logfire.level_num",
+                                    "logfire.msg",
                                 ),
-                                Int(
-                                    17,
+                                String(
+                                    Owned(
+                                        "panic: oh no!",
+                                    ),
                                 ),
                             ),
                         ),
                     ],
                     overflow: Some(
                         [
-                            Some(
-                                (
-                                    Static(
-                                        "logfire.msg",
-                                    ),
-                                    String(
-                                        Owned(
-                                            "panic: oh no!",
-                                        ),
-                                    ),
-                                ),
-                            ),
                             Some(
                                 (
                                     Static(


### PR DESCRIPTION
Followup to #73 - I realised that this also needs to apply to the bridge from the `log` crate.