### PR TITLE
support tracing metrics layer

### DIFF
--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -2132,7 +2132,7 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = set_local_logfire(handler.clone());
+        let _guard = set_local_logfire(handler.clone());
 
         tracing::info!(counter.test_counter = 1, "test counter event");
         tracing::info!(histogram.test_histogram = 2.5, "test histogram event");

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,15 +188,11 @@ impl std::fmt::Debug for Target {
 /// Options primarily used for testing by Logfire developers.
 #[derive(Default)]
 pub struct AdvancedOptions {
-    /// Root URL for the Logfire API.
     pub(crate) base_url: Option<String>,
-    /// Generator for trace and span IDs.
     pub(crate) id_generator: Option<BoxedIdGenerator>,
-    /// Resource to override default resource detection.
     pub(crate) resource: Option<opentelemetry_sdk::Resource>,
-
-    // Configuration for OpenTelemetry logging. This is experimental and may be removed.
     pub(crate) log_record_processors: Vec<BoxedLogProcessor>,
+    pub(crate) enable_tracing_metrics: bool,
     //
     //
     // TODO: arguments below supported by Python
@@ -230,7 +226,7 @@ impl AdvancedOptions {
         self
     }
 
-    /// Add a log processor to the list of log processors.
+    /// Add a log processor to the list of log processors. This is experimental and may be removed.
     #[must_use]
     pub fn with_log_processor<T: LogProcessor + Send + Sync + 'static>(
         mut self,
@@ -238,6 +234,13 @@ impl AdvancedOptions {
     ) -> Self {
         self.log_record_processors
             .push(BoxedLogProcessor::new(Box::new(processor)));
+        self
+    }
+
+    /// Support capturing tracing events as metrics as per [`tracing_opentelemetry::MetricsLayer`](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.MetricsLayer.html).
+    #[must_use]
+    pub fn with_tracing_metrics(mut self, enable: bool) -> Self {
+        self.enable_tracing_metrics = enable;
         self
     }
 }

--- a/src/internal/logfire_tracer.rs
+++ b/src/internal/logfire_tracer.rs
@@ -10,13 +10,14 @@ use opentelemetry::{
     logs::{AnyValue, LogRecord, Logger, Severity},
     trace::TraceContextExt,
 };
-use opentelemetry_sdk::{logs::SdkLogger, trace::Tracer};
+use opentelemetry_sdk::{logs::SdkLogger, metrics::SdkMeterProvider, trace::Tracer};
 
 use crate::__macros_impl::LogfireValue;
 
 #[derive(Clone)]
 pub(crate) struct LogfireTracer {
     pub(crate) inner: Tracer,
+    pub(crate) meter_provider: SdkMeterProvider,
     pub(crate) logger: Arc<SdkLogger>,
     pub(crate) handle_panics: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,7 @@ impl LogfireConfigBuilder {
             tracer_provider,
             meter_provider,
             logger_provider,
+            enable_tracing_metrics,
             ..
         } = self.build_parts(None)?;
 
@@ -369,6 +370,7 @@ impl LogfireConfigBuilder {
             subscriber,
             meter_provider,
             logger_provider,
+            enable_tracing_metrics,
         })
     }
 
@@ -533,7 +535,10 @@ impl LogfireConfigBuilder {
             handle_panics: self.install_panic_handler,
         };
 
-        let subscriber = subscriber.with(LogfireTracingLayer::new(tracer.clone()));
+        let subscriber = subscriber.with(LogfireTracingLayer::new(
+            tracer.clone(),
+            advanced_options.enable_tracing_metrics,
+        ));
 
         if self.install_panic_handler {
             install_panic_handler();
@@ -546,6 +551,7 @@ impl LogfireConfigBuilder {
             tracer_provider,
             meter_provider,
             logger_provider,
+            enable_tracing_metrics: advanced_options.enable_tracing_metrics,
             #[cfg(test)]
             send_to_logfire,
         })
@@ -564,6 +570,7 @@ pub struct ShutdownHandler {
     subscriber: Arc<dyn Subscriber + Send + Sync>,
     meter_provider: SdkMeterProvider,
     logger_provider: SdkLoggerProvider,
+    enable_tracing_metrics: bool,
 }
 
 impl ShutdownHandler {
@@ -615,7 +622,7 @@ impl ShutdownHandler {
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
     {
-        LogfireTracingLayer::new(self.tracer.clone())
+        LogfireTracingLayer::new(self.tracer.clone(), self.enable_tracing_metrics)
     }
 }
 
@@ -626,6 +633,7 @@ struct LogfireParts {
     tracer_provider: SdkTracerProvider,
     meter_provider: SdkMeterProvider,
     logger_provider: SdkLoggerProvider,
+    enable_tracing_metrics: bool,
     #[cfg(test)]
     send_to_logfire: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,7 @@ impl LogfireConfigBuilder {
 
         let tracer = LogfireTracer {
             inner: tracer,
+            meter_provider: meter_provider.clone(),
             logger,
             handle_panics: self.install_panic_handler,
         };

--- a/src/usage/metrics.rs
+++ b/src/usage/metrics.rs
@@ -135,13 +135,12 @@
 //!
 //! ## Using Metrics in Logfire Dashboards
 //!
-//! Once your metrics are being exported to Logfire, you can create dashboards and alerts:
+//! Once your metrics are being exported to Logfire, you can create dashboards and alerts. To check metrics
+//! arriving in Logfire, you can use the following steps:
 //!
-//! ### 1. **View Metrics in Logfire**
-//!
-//! - Navigate to your Logfire project dashboard
-//! - Go to the ["Explore"](https://logfire.pydantic.dev/docs/guides/web-ui/explore/) view
-//! - Run `select * from metrics` to view all incoming metrics from your application
+//! 1. Navigate to your Logfire project dashboard
+//! 2. Go to the ["Explore"](https://logfire.pydantic.dev/docs/guides/web-ui/explore/) view
+//! 3. Run `select * from metrics` to view all incoming metrics from your application
 //!
 //! ## Best Practices
 //!
@@ -151,6 +150,18 @@
 //! 4. **Appropriate Units**: Specify units (seconds, bytes, requests) for better dashboard formatting
 //! 5. **Documentation**: Add descriptions to help with dashboard creation
 //! 6. **Label Cardinality**: Be careful with high-cardinality labels (e.g., user IDs) - prefer aggregated metrics
+//!
+//! ## `tracing-opentelemetry` metrics
+//!
+//! `tracing-opentelemetry` has its own
+//! [`MetricsLayer`](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.MetricsLayer.html) which
+//! can be used to automatically produce metrics from `tracing` events.
+//!
+//! Reporting metrics through this pattern adds a level of indirection compared to the direct use of the logfire metrics API described
+//! above. In some cases, however, this may be useful, or necessary if dependencies are emitting
+//! metrics in this form.
+//!
+//! This SDK provides a built-in way to handle these metrics via [`AdvancedOptions::with_tracing_metrics`][crate::config::AdvancedOptions::with_tracing_metrics].
 //!
 //! ## Troubleshooting
 //!

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1657,10 +1657,13 @@ async fn test_basic_metrics() {
                         schema_url: None,
                         attributes: [],
                     },
-                    sum_metrics: [
-                        [
-                            1,
-                        ],
+                    metrics: [
+                        DeterministicMetric {
+                            name: "basic_counter",
+                            values: [
+                                1,
+                            ],
+                        },
                     ],
                 },
             ],
@@ -1688,10 +1691,13 @@ async fn test_basic_metrics() {
                         schema_url: None,
                         attributes: [],
                     },
-                    sum_metrics: [
-                        [
-                            2,
-                        ],
+                    metrics: [
+                        DeterministicMetric {
+                            name: "basic_counter",
+                            values: [
+                                2,
+                            ],
+                        },
                     ],
                 },
             ],


### PR DESCRIPTION
Adds an advanced option to enable collecting metrics from tracing events using the `tracing-opentelemetry::MetricsLayer` pattern.