### PR TITLE
fix setting resource on custom log processor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -405,14 +405,12 @@ impl MetricReader for BoxedMetricReader {
 
 /// Boxed log processor for dynamic dispatch
 #[derive(Debug)]
-pub(crate) struct BoxedLogProcessor {
-    inner: Box<dyn LogProcessor + Send + Sync>,
-}
+pub(crate) struct BoxedLogProcessor(Box<dyn LogProcessor + Send + Sync>);
 
 impl BoxedLogProcessor {
     /// Create a new boxed log processor.
     pub fn new(processor: Box<dyn LogProcessor + Send + Sync>) -> Self {
-        Self { inner: processor }
+        Self(processor)
     }
 }
 
@@ -422,15 +420,26 @@ impl LogProcessor for BoxedLogProcessor {
         log_record: &mut opentelemetry_sdk::logs::SdkLogRecord,
         instrumentation_scope: &opentelemetry::InstrumentationScope,
     ) {
-        self.inner.emit(log_record, instrumentation_scope);
+        self.0.emit(log_record, instrumentation_scope);
     }
 
     fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
-        self.inner.force_flush()
+        self.0.force_flush()
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.0.shutdown_with_timeout(timeout)
     }
 
     fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
-        self.inner.shutdown()
+        self.0.shutdown()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.0.set_resource(resource);
     }
 }
 

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use insta::assert_debug_snapshot;
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
     Resource,
     logs::{InMemoryLogExporter, SimpleLogProcessor},
@@ -49,7 +50,12 @@ fn test_basic_span() {
         .with_advanced_options(
             AdvancedOptions::default()
                 .with_id_generator(DeterministicIdGenerator::new())
-                .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
+                .with_log_processor(SimpleLogProcessor::new(log_exporter.clone()))
+                .with_resource(
+                    Resource::builder_empty()
+                        .with_attribute(KeyValue::new("resource.key", "value"))
+                        .build(),
+                ),
         )
         .finish()
         .unwrap();
@@ -120,7 +126,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        27,
+                        32,
                     ),
                 },
                 KeyValue {
@@ -246,7 +252,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        28,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -402,7 +408,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        28,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -564,7 +570,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        29,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -700,7 +706,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        29,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -842,7 +848,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        30,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -978,7 +984,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        30,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -1120,7 +1126,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        27,
+                        32,
                     ),
                 },
                 KeyValue {
@@ -1292,7 +1298,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    31,
+                                    36,
                                 ),
                             ),
                         ),
@@ -1459,7 +1465,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    32,
+                                    37,
                                 ),
                             ),
                         ),


### PR DESCRIPTION
Noticed this downstream.

Would be nice to be able to test it's wired up, I'll write a PR to OTEL SDK to support getting the resource from the in-memory exporters so we can check it's correct. That shouldn't need to block merge.