### PR TITLE
fix case where tracing `enabled` caused too-verbose logging

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -7,35 +7,22 @@ use crate::internal::logfire_tracer::LogfireTracer;
 
 pub(crate) struct LogfireLogger {
     tracer: LogfireTracer,
-    filter: env_filter::Filter,
 }
 
 impl LogfireLogger {
     pub(crate) fn init(tracer: LogfireTracer) -> &'static Self {
         static LOGGER: OnceLock<LogfireLogger> = OnceLock::new();
-        LOGGER.get_or_init(move || {
-            let mut filter_builder = env_filter::Builder::new();
-            if let Ok(filter) = std::env::var("RUST_LOG") {
-                filter_builder.parse(&filter);
-            } else {
-                filter_builder.filter_level(log::LevelFilter::Info);
-            }
-
-            LogfireLogger {
-                tracer,
-                filter: filter_builder.build(),
-            }
-        })
+        LOGGER.get_or_init(move || LogfireLogger { tracer })
     }
 
     pub(crate) fn max_level(&self) -> LevelFilter {
-        self.filter.filter()
+        self.tracer.filter.filter()
     }
 }
 
 impl log::Log for LogfireLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        self.filter.enabled(metadata)
+        self.tracer.enabled(metadata)
     }
 
     fn log(&self, record: &Record) {
@@ -108,7 +95,6 @@ mod tests {
 
         let lf_logger = LogfireLogger {
             tracer: handler.tracer.clone(),
-            filter: env_filter::Builder::new().parse("trace").build(),
         };
 
         log::set_max_level(log::LevelFilter::Trace);
@@ -190,7 +176,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        28,
+                                        27,
                                     ),
                                 ),
                             ),
@@ -333,7 +319,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        29,
+                                        28,
                                     ),
                                 ),
                             ),
@@ -476,7 +462,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        32,
+                                        31,
                                     ),
                                 ),
                             ),
@@ -619,7 +605,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        33,
+                                        32,
                                     ),
                                 ),
                             ),
@@ -762,7 +748,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        34,
+                                        33,
                                     ),
                                 ),
                             ),
@@ -905,7 +891,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        35,
+                                        34,
                                     ),
                                 ),
                             ),
@@ -1048,7 +1034,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        36,
+                                        35,
                                     ),
                                 ),
                             ),
@@ -1155,7 +1141,6 @@ mod tests {
 
         let lf_logger = LogfireLogger {
             tracer: handler.tracer.clone(),
-            filter: env_filter::Builder::new().parse("trace").build(),
         };
 
         log::set_max_level(log::LevelFilter::Trace);

--- a/src/internal/logfire_tracer.rs
+++ b/src/internal/logfire_tracer.rs
@@ -5,6 +5,8 @@ use std::{
     time::SystemTime,
 };
 
+use crate::__macros_impl::LogfireValue;
+use log::Metadata;
 use opentelemetry::{
     Array, Value,
     logs::{AnyValue, LogRecord, Logger, Severity},
@@ -12,14 +14,13 @@ use opentelemetry::{
 };
 use opentelemetry_sdk::{logs::SdkLogger, metrics::SdkMeterProvider, trace::Tracer};
 
-use crate::__macros_impl::LogfireValue;
-
 #[derive(Clone)]
 pub(crate) struct LogfireTracer {
     pub(crate) inner: Tracer,
     pub(crate) meter_provider: SdkMeterProvider,
     pub(crate) logger: Arc<SdkLogger>,
     pub(crate) handle_panics: bool,
+    pub(crate) filter: Arc<env_filter::Filter>,
 }
 
 // Global tracer configured in `logfire::configure()`
@@ -46,6 +47,10 @@ impl LogfireTracer {
         }
 
         GLOBAL_TRACER.get().map(f.expect("local tls not used"))
+    }
+
+    pub fn enabled(&self, metadata: &Metadata) -> bool {
+        self.filter.enabled(metadata)
     }
 
     #[expect(clippy::too_many_arguments)] // FIXME probably can group these


### PR DESCRIPTION
Best understood from the test.

I ran across an issue using this downstream where setting a tracing subscriber which potentially allows `TRACE` level events would cause _all_ logs to be emitted even if the primary log level was INFO.

This moves filtering into the `LogfireTracer` for the log system, which has a nice effect of making the `log` bridge thinner at the same time.