### PR TITLE
logs: stop sending `logfire.msg`, test `event_name` properly

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -118,7 +118,9 @@ mod tests {
         [
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -207,28 +209,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "root event",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -261,7 +251,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -350,28 +342,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "root event with target",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -404,7 +384,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -493,28 +475,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "hello world log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -547,7 +517,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -636,28 +608,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "warning log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -690,7 +650,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -779,28 +741,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "error log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -833,7 +783,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -922,28 +874,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "debug log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -976,7 +916,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "log message",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -1065,28 +1007,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "trace log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -1397,7 +1397,9 @@ mod tests {
         [
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "event src/bridges/tracing.rs:434",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -1486,28 +1488,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "root event",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -1540,7 +1530,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "root event with value",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -1644,18 +1636,6 @@ mod tests {
                                 Some(
                                     (
                                         Static(
-                                            "logfire.msg",
-                                        ),
-                                        String(
-                                            Owned(
-                                                "root event with value",
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                                Some(
-                                    (
-                                        Static(
                                             "thread.id",
                                         ),
                                         Int(
@@ -1695,7 +1675,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "event src/bridges/tracing.rs:442",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -1784,28 +1766,16 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "logfire.msg",
+                                        "thread.id",
                                     ),
-                                    String(
-                                        Owned(
-                                            "hello world log",
-                                        ),
+                                    Int(
+                                        0,
                                     ),
                                 ),
                             ),
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "thread.id",
-                                        ),
-                                        Int(
-                                            0,
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(
@@ -1838,7 +1808,9 @@ mod tests {
             },
             LogDataWithResource {
                 record: SdkLogRecord {
-                    event_name: None,
+                    event_name: Some(
+                        "hello world log with value",
+                    ),
                     target: None,
                     timestamp: Some(
                         SystemTime {
@@ -1939,18 +1911,6 @@ mod tests {
                         ],
                         overflow: Some(
                             [
-                                Some(
-                                    (
-                                        Static(
-                                            "logfire.msg",
-                                        ),
-                                        String(
-                                            Owned(
-                                                "hello world log with value",
-                                            ),
-                                        ),
-                                    ),
-                                ),
                                 Some(
                                     (
                                         Static(

--- a/src/internal/logfire_tracer.rs
+++ b/src/internal/logfire_tracer.rs
@@ -88,7 +88,7 @@ impl LogfireTracer {
         log_record.set_event_name(name);
         log_record.set_timestamp(ts);
         log_record.set_observed_timestamp(ts);
-        log_record.set_body(message.clone().into());
+        log_record.set_body(message.into());
         log_record.set_severity_text(severity.name());
         log_record.set_severity_number(severity);
 
@@ -119,7 +119,6 @@ impl LogfireTracer {
             }
         }
 
-        log_record.add_attribute("logfire.msg", message);
         log_record.add_attribute("logfire.json_schema", schema);
         log_record.add_attribute("thread.id", THREAD_ID.with(|id| *id));
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -279,10 +279,8 @@ pub fn find_log<'a>(logs: &'a [LogDataWithResource], name: &str) -> &'a LogDataW
     logs.iter()
         .find(|log| {
             log.record
-                .attributes_iter()
-                .find(|(key, _)| key.as_str() == "logfire.msg")
-                .map(|(_, value)| format!("{:?}", value).contains(name))
-                .unwrap_or(false)
+                .event_name()
+                .is_some_and(|event_name| event_name == name)
         })
         .expect("log present")
 }
@@ -331,6 +329,10 @@ pub fn make_deterministic_logs(
                         .remap_timestamp(observed_timestamp),
                 );
             }
+            if let Some(event_name) = original_record.event_name() {
+                new_record.set_event_name(event_name);
+            }
+
             if let Some(trace_context) = original_record.trace_context() {
                 new_record.set_trace_context(
                     trace_context.trace_id,

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -62,13 +62,15 @@ fn test_basic_span() {
 
     let guard = logfire::set_local_logfire(handler);
 
+    let value = 42;
+
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         tracing::subscriber::with_default(guard.subscriber(), || {
             let root = span!("root span").entered();
             let _ = span!("hello world span", attr = "x", dotted.attr = "y").entered();
             let _ = span!(level: Level::DEBUG, "debug span");
             let _ = span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
-            info!("hello world log", attr = "x", dotted.attr = "y");
+            info!("hello world log {value}", attr = "x", dotted.attr = "y");
             panic!("oh no!");
         });
     }))
@@ -126,7 +128,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        32,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -252,7 +254,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        33,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -408,7 +410,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        33,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -570,7 +572,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        36,
                     ),
                 },
                 KeyValue {
@@ -706,7 +708,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        36,
                     ),
                 },
                 KeyValue {
@@ -848,7 +850,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        37,
                     ),
                 },
                 KeyValue {
@@ -984,7 +986,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        37,
                     ),
                 },
                 KeyValue {
@@ -1126,7 +1128,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        32,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -1228,7 +1230,9 @@ fn test_basic_span() {
     [
         LogDataWithResource {
             record: SdkLogRecord {
-                event_name: None,
+                event_name: Some(
+                    "hello world log {value}",
+                ),
                 target: None,
                 timestamp: Some(
                     SystemTime {
@@ -1262,7 +1266,7 @@ fn test_basic_span() {
                 body: Some(
                     String(
                         Owned(
-                            "hello world log",
+                            "hello world log 42",
                         ),
                     ),
                 ),
@@ -1298,7 +1302,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    36,
+                                    38,
                                 ),
                             ),
                         ),
@@ -1337,18 +1341,6 @@ fn test_basic_span() {
                                     String(
                                         Static(
                                             "{\"type\":\"object\",\"properties\":{\"attr\":{},\"dotted.attr\":{}}}",
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            Some(
-                                (
-                                    Static(
-                                        "logfire.msg",
-                                    ),
-                                    String(
-                                        Owned(
-                                            "hello world log",
                                         ),
                                     ),
                                 ),
@@ -1395,7 +1387,9 @@ fn test_basic_span() {
         },
         LogDataWithResource {
             record: SdkLogRecord {
-                event_name: None,
+                event_name: Some(
+                    "panic",
+                ),
                 target: None,
                 timestamp: Some(
                     SystemTime {
@@ -1465,7 +1459,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    37,
+                                    39,
                                 ),
                             ),
                         ),
@@ -1484,28 +1478,16 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "logfire.msg",
+                                    "thread.id",
                                 ),
-                                String(
-                                    Owned(
-                                        "panic: oh no!",
-                                    ),
+                                Int(
+                                    0,
                                 ),
                             ),
                         ),
                     ],
                     overflow: Some(
                         [
-                            Some(
-                                (
-                                    Static(
-                                        "thread.id",
-                                    ),
-                                    Int(
-                                        0,
-                                    ),
-                                ),
-                            ),
                             Some(
                                 (
                                     Static(


### PR DESCRIPTION
It should be the case that:
- `event_name` becomes the `span_name` on logfire UI
- string body becomes the message on the logfire UI

no need to send `logfire.msg` as an extra attribute, that's just dead weight.