### PR TITLE
don't fabricate "panic" and "log message" event names

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -28,7 +28,7 @@ impl log::Log for LogfireLogger {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             self.tracer.export_log(
-                "log message",
+                record.args().as_str(),
                 &tracing::Span::current().context(),
                 record.args().to_string(),
                 level_to_severity(record.level()),
@@ -119,7 +119,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "root event",
                     ),
                     target: None,
                     timestamp: Some(
@@ -252,7 +252,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "root event with target",
                     ),
                     target: None,
                     timestamp: Some(
@@ -385,7 +385,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "hello world log",
                     ),
                     target: None,
                     timestamp: Some(
@@ -518,7 +518,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "warning log",
                     ),
                     target: None,
                     timestamp: Some(
@@ -651,7 +651,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "error log",
                     ),
                     target: None,
                     timestamp: Some(
@@ -784,7 +784,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "debug log",
                     ),
                     target: None,
                     timestamp: Some(
@@ -917,7 +917,7 @@ mod tests {
             LogDataWithResource {
                 record: SdkLogRecord {
                     event_name: Some(
-                        "log message",
+                        "trace log",
                     ),
                     target: None,
                     timestamp: Some(

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -347,7 +347,7 @@ fn emit_event_as_log_span(
         .collect();
 
     tracer.export_log(
-        event.metadata().name(),
+        Some(event.metadata().name()),
         parent_context,
         message,
         tracing_level_to_severity(*event.metadata().level()),

--- a/src/internal/logfire_tracer.rs
+++ b/src/internal/logfire_tracer.rs
@@ -56,7 +56,7 @@ impl LogfireTracer {
     #[expect(clippy::too_many_arguments)] // FIXME probably can group these
     pub fn export_log(
         &self,
-        name: &'static str,
+        name: Option<&'static str>,
         parent_context: &opentelemetry::Context,
         message: String,
         severity: Severity,
@@ -85,7 +85,10 @@ impl LogfireTracer {
 
         let ts = SystemTime::now();
 
-        log_record.set_event_name(name);
+        if let Some(name) = name {
+            log_record.set_event_name(name);
+        }
+
         log_record.set_timestamp(ts);
         log_record.set_observed_timestamp(ts);
         log_record.set_body(message.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ fn install_panic_handler() {
 
             let location = info.location();
             tracer.export_log(
-                "panic",
+                None,
                 &tracing::Span::current().context(),
                 format!("panic: {message}"),
                 Severity::Error,

--- a/src/macros/impl_.rs
+++ b/src/macros/impl_.rs
@@ -161,7 +161,7 @@ pub fn export_log(
 ) {
     LogfireTracer::try_with(|tracer| {
         tracer.export_log(
-            name,
+            Some(name),
             &parent_span.context(),
             message,
             tracing_level_to_severity(level),

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1387,9 +1387,7 @@ fn test_basic_span() {
         },
         LogDataWithResource {
             record: SdkLogRecord {
-                event_name: Some(
-                    "panic",
-                ),
+                event_name: None,
                 target: None,
                 timestamp: Some(
                     SystemTime {


### PR DESCRIPTION
In the case of the panic handler and the `log` crate bridge, we were setting a default event name because there was nothing better to send.

This doesn't look great in the logfire UI, lots of stuff gets grouped into these super generic event names.

I think better not to send them, instead the formatted message will be used as the name.