### PR TITLE
create a proper `Logfire` type

### DIFF
--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -49,10 +49,11 @@ struct CreateUserRequest {
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Logfire
-    let shutdown_handler = logfire::configure()
+    let logfire = logfire::configure()
         .install_panic_handler()
         .finish()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let _guard = logfire.shutdown_guard();
 
     logfire::info!("Starting Actix Web server with Logfire integration");
 
@@ -72,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .run()
     .await?;
 
-    shutdown_handler.shutdown()?;
+    // Shutdown handled automatically by the guard
 
     Ok(())
 }

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -59,7 +59,8 @@ struct CreateUserRequest {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Logfire
-    let shutdown_handler = logfire::configure().install_panic_handler().finish()?;
+    let logfire = logfire::configure().install_panic_handler().finish()?;
+    let _guard = logfire.shutdown_guard();
 
     logfire::info!("Starting Axum server with Logfire integration");
 
@@ -72,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     axum::serve(listener, app).await?;
 
-    shutdown_handler.shutdown()?;
+    // Shutdown handled automatically by the guard
 
     Ok(())
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,7 +15,8 @@ static FILES_COUNTER: LazyLock<Counter<u64>> = LazyLock::new(|| {
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() -> Result<()> {
-    let shutdown_handler = logfire::configure().install_panic_handler().finish()?;
+    let logfire = logfire::configure().install_panic_handler().finish()?;
+    let _guard = logfire.shutdown_guard();
 
     let mut total_size = 0u64;
 
@@ -53,6 +54,5 @@ fn main() -> Result<()> {
         size = total_size as i64
     );
 
-    shutdown_handler.shutdown()?;
     Ok(())
 }

--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -78,7 +78,7 @@ mod tests {
 
         let log_exporter = InMemoryLogExporter::default();
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .install_panic_handler()
@@ -94,11 +94,11 @@ mod tests {
             .unwrap();
 
         let lf_logger = LogfireLogger {
-            tracer: handler.tracer.clone(),
+            tracer: logfire.tracer.clone(),
         };
 
         log::set_max_level(log::LevelFilter::Trace);
-        let guard = set_local_logfire(handler);
+        let guard = set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             log::info!(logger: lf_logger, "root event");
@@ -1060,7 +1060,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(tracing::Level::TRACE)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options.clone()))
@@ -1070,11 +1070,11 @@ mod tests {
             .unwrap();
 
         let lf_logger = LogfireLogger {
-            tracer: handler.tracer.clone(),
+            tracer: logfire.tracer.clone(),
         };
 
         log::set_max_level(log::LevelFilter::Trace);
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             log::info!(logger: lf_logger, "root event");
@@ -1087,7 +1087,7 @@ mod tests {
             log::trace!(logger: lf_logger, "trace log");
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -1101,8 +1101,6 @@ mod tests {
         [2m1970-01-01T00:00:00.000004Z[0m[33m  WARN[0m [2;3mlogfire::bridges::log::tests[0m [1mwarning log[0m
         [2m1970-01-01T00:00:00.000005Z[0m[31m ERROR[0m [2;3mlogfire::bridges::log::tests[0m [1merror log[0m
         [2m1970-01-01T00:00:00.000006Z[0m[35m TRACE[0m [2;3mlogfire::bridges::log::tests[0m [1mtrace log[0m
-        [2m1970-01-01T00:00:00.000007Z[0m[34m DEBUG[0m [2;3mopentelemetry_sdk::metrics::meter_provider[0m [1mUser initiated shutdown of MeterProvider.[0m [3mname[0m=MeterProvider.Shutdown
-        [2m1970-01-01T00:00:00.000008Z[0m[34m DEBUG[0m [2;3mopentelemetry_sdk::logs::logger_provider[0m [1m[0m [3mname[0m=LoggerProvider.ShutdownInvokedByUser
         ");
     }
 }

--- a/src/exporters.rs
+++ b/src/exporters.rs
@@ -8,7 +8,7 @@ use opentelemetry_sdk::{
 };
 
 use crate::{
-    ConfigureError, get_optional_env,
+    ConfigureError, internal::env::get_optional_env,
     internal::exporters::remove_pending::RemovePendingSpansExporter,
 };
 

--- a/src/internal/env.rs
+++ b/src/internal/env.rs
@@ -1,0 +1,23 @@
+use std::{collections::HashMap, env::VarError};
+
+use crate::ConfigureError;
+
+/// Internal helper to get the `key` from the environment.
+///
+/// If `env` is provided, will use that instead of the process environment.
+pub fn get_optional_env(
+    key: &str,
+    env: Option<&HashMap<String, String>>,
+) -> Result<Option<String>, ConfigureError> {
+    if let Some(env) = env {
+        Ok(env.get(key).cloned())
+    } else {
+        match std::env::var(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(VarError::NotPresent) => Ok(None),
+            Err(VarError::NotUnicode(_)) => Err(ConfigureError::Other(
+                format!("{key} is not valid UTF-8").into(),
+            )),
+        }
+    }
+}

--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -406,7 +406,7 @@ mod tests {
             .with_target(Target::Pipe(output.clone()))
             .with_min_log_level(Level::TRACE);
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -415,7 +415,7 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = set_local_logfire(handler);
+        let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             tracing::subscriber::with_default(guard.subscriber().clone(), || {
@@ -429,7 +429,7 @@ mod tests {
         }))
         .unwrap_err();
 
-        drop(guard);
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -454,7 +454,7 @@ mod tests {
             .with_include_timestamps(false)
             .with_min_log_level(Level::TRACE);
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -463,7 +463,7 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = set_local_logfire(handler);
+        let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             tracing::subscriber::with_default(guard.subscriber().clone(), || {
@@ -477,7 +477,7 @@ mod tests {
         }))
         .unwrap_err();
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -490,8 +490,6 @@ mod tests {
         [34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
         [31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
-        [34m DEBUG[0m [2;3mopentelemetry_sdk::metrics::meter_provider[0m [1mUser initiated shutdown of MeterProvider.[0m [3mname[0m=MeterProvider.Shutdown
-        [34m DEBUG[0m [2;3mopentelemetry_sdk::logs::logger_provider[0m [1m[0m [3mname[0m=LoggerProvider.ShutdownInvokedByUser
         ");
     }
 
@@ -503,7 +501,7 @@ mod tests {
             .with_target(Target::Pipe(output.clone()))
             .with_min_log_level(Level::INFO);
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -512,7 +510,7 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = set_local_logfire(handler);
+        let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             tracing::subscriber::with_default(guard.subscriber().clone(), || {
@@ -526,7 +524,7 @@ mod tests {
         }))
         .unwrap_err();
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -537,8 +535,6 @@ mod tests {
         [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world span[0m
         [2m1970-01-01T00:00:00.000002Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
         [2m1970-01-01T00:00:00.000003Z[0m[31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
-        [2m1970-01-01T00:00:00.000004Z[0m[34m DEBUG[0m [2;3mopentelemetry_sdk::metrics::meter_provider[0m [1mUser initiated shutdown of MeterProvider.[0m [3mname[0m=MeterProvider.Shutdown
-        [2m1970-01-01T00:00:00.000005Z[0m[34m DEBUG[0m [2;3mopentelemetry_sdk::logs::logger_provider[0m [1m[0m [3mname[0m=LoggerProvider.ShutdownInvokedByUser
         ");
     }
 

--- a/src/internal/exporters/remove_pending.rs
+++ b/src/internal/exporters/remove_pending.rs
@@ -112,7 +112,7 @@ mod tests {
             let _debug = crate::span!(level: Level::DEBUG, "debug span").entered();
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let mut spans = exporter.get_finished_spans().unwrap();
         spans.sort_unstable_by(|a, b| a.name.cmp(&b.name));

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod constants;
+pub(crate) mod env;
 pub(crate) mod exporters;
 pub(crate) mod logfire_tracer;
 pub(crate) mod span_data_ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,16 @@
 //!
 //! ```rust
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let shutdown_handler = logfire::configure()
+//!     let logfire = logfire::configure()
 //!         .install_panic_handler()
 //! #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
 //!         .finish()?;
 //!
+//!     let _guard = logfire.shutdown_guard();
+//!
 //!     logfire::info!("Hello world");
 //!
-//!     shutdown_handler.shutdown()?;
+//!     // Guard automatically shuts down Logfire when it goes out of scope
 //!     Ok(())
 //! }
 //! ```
@@ -74,40 +76,9 @@
 //!
 //! [`LOGFIRE_TOKEN`]: https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/
 
-use std::{
-    backtrace::Backtrace,
-    borrow::Cow,
-    collections::HashMap,
-    env::VarError,
-    panic::PanicHookInfo,
-    sync::{Arc, Once},
-    time::Duration,
-};
-
-use config::get_base_url_from_token;
-use opentelemetry::{
-    logs::{LoggerProvider as _, Severity},
-    trace::TracerProvider,
-};
-use opentelemetry_sdk::{
-    logs::{BatchLogProcessor, SdkLoggerProvider},
-    metrics::{PeriodicReader, SdkMeterProvider},
-    trace::{BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider, SpanProcessor},
-};
 use thiserror::Error;
-use tracing::{Subscriber, level_filters::LevelFilter, subscriber::DefaultGuard};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
-use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan};
 
-use crate::{
-    __macros_impl::LogfireValue,
-    config::{AdvancedOptions, BoxedSpanProcessor, ConsoleOptions, MetricsOptions, SendToLogfire},
-    internal::{
-        exporters::console::{ConsoleWriter, create_console_processors},
-        logfire_tracer::{GLOBAL_TRACER, LOCAL_TRACER, LogfireTracer},
-    },
-    ulid_id_generator::UlidIdGenerator,
-};
+use crate::config::LogfireConfigBuilder;
 
 mod macros;
 
@@ -117,6 +88,7 @@ pub mod usage;
 mod bridges;
 pub mod config;
 pub mod exporters;
+mod logfire;
 mod metrics;
 mod ulid_id_generator;
 
@@ -124,6 +96,7 @@ pub use macros::*;
 pub use metrics::*;
 
 pub use crate::bridges::tracing::LogfireTracingLayer;
+pub use crate::logfire::Logfire;
 
 mod internal;
 
@@ -184,6 +157,15 @@ pub enum ConfigureError {
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// An error which may arise when shutting down Logfire.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ShutdownError {
+    /// The opentelemetry SDK failed to shut down.
+    #[error("Failed to shutdown Otel SDK: {0}")]
+    OtelError(#[from] opentelemetry_sdk::error::OTelSdkError),
+}
+
 /// Main entry point to configure logfire.
 ///
 /// This should be called once at the start of the program.
@@ -194,668 +176,24 @@ pub enum ConfigureError {
 ///
 /// ```rust
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let shutdown_handler = logfire::configure()
+///     let logfire = logfire::configure()
 ///         .install_panic_handler()
 /// #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
 ///         .finish()?;
 ///
+///     let _guard = logfire.shutdown_guard();
+///
 ///     logfire::info!("Hello world");
 ///
-///     shutdown_handler.shutdown()?;
+///     // Guard automatically shuts down Logfire when it goes out of scope
 ///     Ok(())
 /// }
 /// ```
-#[must_use = "call `.finish()` to complete logfire configuration."]
 pub fn configure() -> LogfireConfigBuilder {
-    LogfireConfigBuilder {
-        local: false,
-        send_to_logfire: None,
-        token: None,
-        console_options: Some(ConsoleOptions::default()),
-        additional_span_processors: Vec::new(),
-        advanced: None,
-        metrics: Some(MetricsOptions::default()),
-        enable_metrics: true,
-        install_panic_handler: false,
-        default_level_filter: None,
-    }
+    LogfireConfigBuilder::default()
 }
 
-/// Builder for logfire configuration, returned from [`logfire::configure()`][configure].
-pub struct LogfireConfigBuilder {
-    local: bool,
-    send_to_logfire: Option<SendToLogfire>,
-    token: Option<String>,
-    // service_name: Option<String>,
-    // service_version: Option<String>,
-    // environment: Option<String>,
-    console_options: Option<ConsoleOptions>,
-
-    // config_dir: Option<PathBuf>,
-    // data_dir: Option<Path>,
-
-    // TODO: change to match Python SDK
-    additional_span_processors: Vec<BoxedSpanProcessor>,
-    // tracer_provider: Option<SdkTracerProvider>,
-
-    // TODO: advanced Python options not yet supported by the Rust SDK
-    // scrubbing: ScrubbingOptions | Literal[False] | None = None,
-    // inspect_arguments: bool | None = None,
-    // sampling: SamplingOptions | None = None,
-    // code_source: CodeSource | None = None,
-    // distributed_tracing: bool | None = None,
-    advanced: Option<AdvancedOptions>,
-    metrics: Option<MetricsOptions>,
-    enable_metrics: bool,
-
-    // Rust specific options
-    install_panic_handler: bool,
-    default_level_filter: Option<LevelFilter>,
-}
-
-impl LogfireConfigBuilder {
-    /// Call to configure Logfire for local use only.
-    ///
-    /// This prevents the configured `Logfire` from setting global `tracing`, `log` and `opentelemetry` state.
-    #[doc(hidden)]
-    #[must_use]
-    pub fn local(mut self) -> Self {
-        self.local = true;
-        self
-    }
-
-    /// Call to install a hook to log panics.
-    ///
-    /// Any existing panic hook will be preserved and called after the logfire panic hook.
-    #[must_use]
-    pub fn install_panic_handler(mut self) -> Self {
-        self.install_panic_handler = true;
-        self
-    }
-
-    /// Whether to send data to the Logfire platform.
-    ///
-    /// Defaults to the value of `LOGFIRE_SEND_TO_LOGFIRE` if set, otherwise `Yes`.
-    #[must_use]
-    pub fn send_to_logfire<T: Into<SendToLogfire>>(mut self, send_to_logfire: T) -> Self {
-        self.send_to_logfire = Some(send_to_logfire.into());
-        self
-    }
-
-    /// The token to use for the Logfire platform.
-    ///
-    /// Defaults to the value of `LOGFIRE_TOKEN` if set.
-    #[must_use]
-    pub fn with_token<T: Into<String>>(mut self, token: T) -> Self {
-        self.token = Some(token.into());
-        self
-    }
-
-    /// Sets console options. Set to `None` to disable console logging.
-    ///
-    /// If not set, will use `ConsoleOptions::default()`.
-    #[must_use]
-    pub fn with_console(mut self, console_options: Option<ConsoleOptions>) -> Self {
-        self.console_options = console_options;
-        self
-    }
-
-    /// Override the filter used for traces and logs.
-    ///
-    /// By default this is set to `LevelFilter::TRACE` if sending to logfire, or `LevelFilter::INFO` if not.
-    ///
-    /// The `RUST_LOG` environment variable will override this.
-    #[must_use]
-    pub fn with_default_level_filter(mut self, default_level_filter: LevelFilter) -> Self {
-        self.default_level_filter = Some(default_level_filter);
-        self
-    }
-
-    /// Add an additional span processor to process spans alongside the main logfire exporter.
-    ///
-    /// To disable the main logfire exporter, set `send_to_logfire` to `false`.
-    #[must_use]
-    pub fn with_additional_span_processor<T: SpanProcessor + 'static>(
-        mut self,
-        span_processor: T,
-    ) -> Self {
-        self.additional_span_processors
-            .push(BoxedSpanProcessor::new(Box::new(span_processor)));
-        self
-    }
-
-    /// Configure [advanced options](crate::config::AdvancedOptions).
-    #[must_use]
-    pub fn with_advanced_options(mut self, advanced: AdvancedOptions) -> Self {
-        self.advanced = Some(advanced);
-        self
-    }
-
-    /// Configure [metrics options](crate::config::MetricsOptions).
-    ///
-    /// Set to `None` to disable metrics.
-    #[must_use]
-    pub fn with_metrics(mut self, metrics: Option<MetricsOptions>) -> Self {
-        self.metrics = metrics;
-        self
-    }
-
-    /// Finish configuring Logfire.
-    ///
-    /// Because this configures global state for the opentelemetry SDK, this can typically only ever be called once per program.
-    ///
-    /// # Errors
-    ///
-    /// See [`ConfigureError`] for possible errors.
-    pub fn finish(self) -> Result<ShutdownHandler, ConfigureError> {
-        let LogfireParts {
-            local,
-            tracer,
-            subscriber,
-            tracer_provider,
-            meter_provider,
-            logger_provider,
-            enable_tracing_metrics,
-            ..
-        } = self.build_parts(None)?;
-
-        if !local {
-            tracing::subscriber::set_global_default(subscriber.clone())?;
-            let logger = bridges::log::LogfireLogger::init(tracer.clone());
-            log::set_logger(logger)?;
-            log::set_max_level(logger.max_level());
-
-            GLOBAL_TRACER
-                .set(tracer.clone())
-                .map_err(|_| ConfigureError::AlreadyConfigured)?;
-
-            let propagator = opentelemetry::propagation::TextMapCompositePropagator::new(vec![
-                Box::new(opentelemetry_sdk::propagation::TraceContextPropagator::new()),
-                Box::new(opentelemetry_sdk::propagation::BaggagePropagator::new()),
-            ]);
-            opentelemetry::global::set_text_map_propagator(propagator);
-
-            opentelemetry::global::set_meter_provider(meter_provider.clone());
-        }
-
-        Ok(ShutdownHandler {
-            tracer_provider,
-            tracer,
-            subscriber,
-            meter_provider,
-            logger_provider,
-            enable_tracing_metrics,
-        })
-    }
-
-    #[expect(clippy::too_many_lines)]
-    fn build_parts(
-        self,
-        env: Option<&HashMap<String, String>>,
-    ) -> Result<LogfireParts, ConfigureError> {
-        let mut token = self.token;
-        if token.is_none() {
-            token = get_optional_env("LOGFIRE_TOKEN", env)?;
-        }
-
-        let send_to_logfire = match self.send_to_logfire {
-            Some(send_to_logfire) => send_to_logfire,
-            None => match get_optional_env("LOGFIRE_SEND_TO_LOGFIRE", env)? {
-                Some(value) => value.parse()?,
-                None => SendToLogfire::Yes,
-            },
-        };
-
-        let send_to_logfire = match send_to_logfire {
-            SendToLogfire::Yes => true,
-            SendToLogfire::IfTokenPresent => token.is_some(),
-            SendToLogfire::No => false,
-        };
-
-        let advanced_options = self.advanced.unwrap_or_default();
-
-        let mut tracer_provider_builder = SdkTracerProvider::builder();
-        let mut logger_provider_builder = SdkLoggerProvider::builder();
-
-        if let Some(id_generator) = advanced_options.id_generator {
-            tracer_provider_builder = tracer_provider_builder.with_id_generator(id_generator);
-        } else {
-            tracer_provider_builder =
-                tracer_provider_builder.with_id_generator(UlidIdGenerator::new());
-        }
-
-        if let Some(resource) = advanced_options.resource.clone() {
-            tracer_provider_builder = tracer_provider_builder.with_resource(resource);
-        }
-
-        let mut http_headers: Option<HashMap<String, String>> = None;
-
-        let logfire_base_url = if send_to_logfire {
-            let Some(token) = token else {
-                return Err(ConfigureError::TokenRequired);
-            };
-
-            http_headers
-                .get_or_insert_default()
-                .insert("Authorization".to_string(), format!("Bearer {token}"));
-
-            Some(
-                advanced_options
-                    .base_url
-                    .as_deref()
-                    .unwrap_or_else(|| get_base_url_from_token(&token)),
-            )
-        } else {
-            None
-        };
-
-        if let Some(logfire_base_url) = logfire_base_url {
-            tracer_provider_builder = tracer_provider_builder.with_span_processor(
-                BatchSpanProcessor::builder(exporters::span_exporter(
-                    logfire_base_url,
-                    http_headers.clone(),
-                )?)
-                .with_batch_config(
-                    BatchConfigBuilder::default()
-                        .with_scheduled_delay(Duration::from_millis(500)) // 500 matches Python
-                        .build(),
-                )
-                .build(),
-            );
-        }
-
-        let console_processors = self
-            .console_options
-            .map(|o| create_console_processors(Arc::new(ConsoleWriter::new(o))));
-
-        if let Some((span_processor, log_processor)) = console_processors {
-            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
-            logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
-        }
-
-        for span_processor in self.additional_span_processors {
-            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
-        }
-
-        let tracer_provider = tracer_provider_builder.build();
-
-        let tracer = tracer_provider.tracer("logfire");
-        let default_level_filter = self.default_level_filter.unwrap_or(if send_to_logfire {
-            // by default, send everything to the logfire platform, for best UX
-            LevelFilter::TRACE
-        } else {
-            // but if printing locally, just set INFO
-            LevelFilter::INFO
-        });
-
-        let filter = tracing_subscriber::EnvFilter::builder()
-            .with_default_directive(default_level_filter.into())
-            .from_env()?; // but allow the user to override this with `RUST_LOG`
-
-        let subscriber = tracing_subscriber::registry().with(filter);
-
-        let mut meter_provider_builder = SdkMeterProvider::builder();
-
-        if let Some(logfire_base_url) = logfire_base_url {
-            if self.enable_metrics {
-                let metric_reader = PeriodicReader::builder(exporters::metric_exporter(
-                    logfire_base_url,
-                    http_headers.clone(),
-                )?)
-                .build();
-
-                meter_provider_builder = meter_provider_builder.with_reader(metric_reader);
-            }
-        }
-
-        if let Some(metrics) = self.metrics.filter(|_| self.enable_metrics) {
-            for reader in metrics.additional_readers {
-                meter_provider_builder = meter_provider_builder.with_reader(reader);
-            }
-        }
-
-        if let Some(resource) = advanced_options.resource.clone() {
-            meter_provider_builder = meter_provider_builder.with_resource(resource);
-        }
-
-        let meter_provider = meter_provider_builder.build();
-
-        if let Some(logfire_base_url) = logfire_base_url {
-            logger_provider_builder = logger_provider_builder.with_log_processor(
-                BatchLogProcessor::builder(exporters::log_exporter(
-                    logfire_base_url,
-                    http_headers.clone(),
-                )?)
-                .build(),
-            );
-        }
-
-        for log_processor in advanced_options.log_record_processors {
-            logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
-        }
-
-        if let Some(resource) = advanced_options.resource {
-            logger_provider_builder = logger_provider_builder.with_resource(resource);
-        }
-
-        let logger_provider = logger_provider_builder.build();
-
-        let logger = Arc::new(logger_provider.logger("logfire"));
-
-        let mut filter_builder = env_filter::Builder::new();
-        if let Ok(filter) = std::env::var("RUST_LOG") {
-            filter_builder.parse(&filter);
-        } else {
-            filter_builder.parse(&default_level_filter.to_string());
-        }
-
-        let tracer = LogfireTracer {
-            inner: tracer,
-            meter_provider: meter_provider.clone(),
-            logger,
-            handle_panics: self.install_panic_handler,
-            filter: Arc::new(filter_builder.build()),
-        };
-
-        let subscriber = subscriber.with(LogfireTracingLayer::new(
-            tracer.clone(),
-            advanced_options.enable_tracing_metrics,
-        ));
-
-        if self.install_panic_handler {
-            install_panic_handler();
-        }
-
-        Ok(LogfireParts {
-            local: self.local,
-            tracer,
-            subscriber: Arc::new(subscriber),
-            tracer_provider,
-            meter_provider,
-            logger_provider,
-            enable_tracing_metrics: advanced_options.enable_tracing_metrics,
-            #[cfg(test)]
-            send_to_logfire,
-        })
-    }
-}
-
-/// A handler to shutdown the Logfire configuration.
-///
-/// Calling `.shutdown()` will flush the logfire exporters and make further
-/// logfire calls into no-ops.
-#[derive(Clone)]
-#[must_use = "this should be kept alive until logging should be stopped"]
-pub struct ShutdownHandler {
-    tracer_provider: SdkTracerProvider,
-    tracer: LogfireTracer,
-    subscriber: Arc<dyn Subscriber + Send + Sync>,
-    meter_provider: SdkMeterProvider,
-    logger_provider: SdkLoggerProvider,
-    enable_tracing_metrics: bool,
-}
-
-#[allow(clippy::print_stderr)]
-impl Drop for ShutdownHandler {
-    fn drop(&mut self) {
-        if let Err(error) = self.shutdown() {
-            eprintln!("failed to shutdown logfire cleanly: {error:#?}");
-        }
-    }
-}
-
-impl ShutdownHandler {
-    /// Shutdown the tracer provider.
-    ///
-    /// This will flush all spans and metrics to the exporter.
-    ///
-    /// # Errors
-    ///
-    /// See [`ConfigureError`] for possible errors.
-    pub fn shutdown(&self) -> Result<(), ConfigureError> {
-        // TODO: can this just be done in Drop?
-        self.tracer_provider
-            .shutdown()
-            .map_err(|e| ConfigureError::Other(e.into()))?;
-        self.meter_provider
-            .shutdown()
-            .map_err(|e| ConfigureError::Other(e.into()))?;
-        self.logger_provider
-            .shutdown()
-            .map_err(|e| ConfigureError::Other(e.into()))?;
-        Ok(())
-    }
-
-    /// Get a tracing layer which can be used to embed this `Logfire` instance into a `tracing_subscriber::Registry`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tracing_subscriber::{Registry, layer::SubscriberExt};
-    ///
-    /// let shutdown_handler = logfire::configure()
-    ///    .local()  // use local mode to avoid setting global state
-    ///    .finish()
-    ///    .expect("Failed to configure logfire");
-    ///
-    /// let subscriber = tracing_subscriber::registry()
-    ///    .with(shutdown_handler.tracing_layer());
-    ///
-    /// tracing::subscriber::set_global_default(subscriber)
-    ///    .expect("Failed to set global subscriber");
-    ///
-    /// logfire::info!("Hello world");
-    ///
-    /// shutdown_handler.shutdown().expect("Failed to shutdown logfire");
-    /// ```
-    #[must_use]
-    pub fn tracing_layer<S>(&self) -> LogfireTracingLayer<S>
-    where
-        S: Subscriber + for<'span> LookupSpan<'span>,
-    {
-        LogfireTracingLayer::new(self.tracer.clone(), self.enable_tracing_metrics)
-    }
-}
-
-struct LogfireParts {
-    local: bool,
-    tracer: LogfireTracer,
-    subscriber: Arc<dyn Subscriber + Send + Sync>,
-    tracer_provider: SdkTracerProvider,
-    meter_provider: SdkMeterProvider,
-    logger_provider: SdkLoggerProvider,
-    enable_tracing_metrics: bool,
-    #[cfg(test)]
-    send_to_logfire: bool,
-}
-
-/// Install `handler` as part of a chain of panic handlers.
-fn install_panic_handler() {
-    fn panic_hook(info: &PanicHookInfo) {
-        LogfireTracer::try_with(|tracer| {
-            if !tracer.handle_panics {
-                // this tracer is not handling panics
-                return;
-            }
-
-            let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
-                s
-            } else if let Some(s) = info.payload().downcast_ref::<String>() {
-                s
-            } else {
-                ""
-            };
-
-            let location = info.location();
-            tracer.export_log(
-                None,
-                &tracing::Span::current().context(),
-                format!("panic: {message}"),
-                Severity::Error,
-                crate::__json_schema!(backtrace),
-                location.map(|l| Cow::Owned(l.file().to_string())),
-                location.map(std::panic::Location::line),
-                None,
-                [LogfireValue::new(
-                    "backtrace",
-                    Some(Backtrace::capture().to_string().into()),
-                )],
-            );
-        });
-    }
-
-    static INSTALLED: Once = Once::new();
-    INSTALLED.call_once(|| {
-        let prev = std::panic::take_hook();
-        std::panic::set_hook(Box::new(move |info| {
-            panic_hook(info);
-            prev(info);
-        }));
-    });
-}
-
-/// Internal helper to get the `key` from the environment.
-///
-/// If `env` is provided, will use that instead of the process environment.
-fn get_optional_env(
-    key: &str,
-    env: Option<&HashMap<String, String>>,
-) -> Result<Option<String>, ConfigureError> {
-    if let Some(env) = env {
-        Ok(env.get(key).cloned())
-    } else {
-        match std::env::var(key) {
-            Ok(value) => Ok(Some(value)),
-            Err(VarError::NotPresent) => Ok(None),
-            Err(VarError::NotUnicode(_)) => Err(ConfigureError::Other(
-                format!("{key} is not valid UTF-8").into(),
-            )),
-        }
-    }
-}
-
-/// Helper for installing a logfire guard locally to a thread.
-///
-/// This is a bit of a mess, it's only implemented far enough to make tests pass...
-#[doc(hidden)]
-pub struct LocalLogfireGuard {
-    prior: Option<LogfireTracer>,
-    #[expect(dead_code, reason = "tracing RAII guard")]
-    tracing_guard: DefaultGuard,
-    /// Shutdown handler
-    shutdown_handler: ShutdownHandler,
-}
-
-impl LocalLogfireGuard {
-    /// Get the current tracer.
-    #[must_use]
-    pub fn subscriber(&self) -> Arc<dyn Subscriber + Send + Sync> {
-        self.shutdown_handler.subscriber.clone()
-    }
-
-    /// Ge the current meter provider
-    #[must_use]
-    pub fn meter_provider(&self) -> &SdkMeterProvider {
-        &self.shutdown_handler.meter_provider
-    }
-}
-
-impl Drop for LocalLogfireGuard {
-    fn drop(&mut self) {
-        // FIXME: if drop order is not consistent with creation order, does this create strange
-        // state?
-        LOCAL_TRACER.with_borrow_mut(|local_logfire| {
-            *local_logfire = self.prior.take();
-        });
-    }
-}
-
-#[doc(hidden)] // used in tests
-#[must_use]
-pub fn set_local_logfire(shutdown_handler: ShutdownHandler) -> LocalLogfireGuard {
-    let prior = LOCAL_TRACER
-        .with_borrow_mut(|local_logfire| local_logfire.replace(shutdown_handler.tracer.clone()));
-
-    let tracing_guard = tracing::subscriber::set_default(shutdown_handler.subscriber.clone());
-
-    // TODO: metrics??
-
-    LocalLogfireGuard {
-        prior,
-        tracing_guard,
-        shutdown_handler,
-    }
-}
+pub use crate::logfire::set_local_logfire;
 
 #[cfg(test)]
 mod test_utils;
-
-#[cfg(test)]
-mod tests {
-    use crate::{ConfigureError, config::SendToLogfire};
-
-    #[test]
-    fn test_send_to_logfire() {
-        for (env, setting, expected) in [
-            (vec![], None, Err(ConfigureError::TokenRequired)),
-            (vec![("LOGFIRE_TOKEN", "a")], None, Ok(true)),
-            (vec![("LOGFIRE_SEND_TO_LOGFIRE", "no")], None, Ok(false)),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "yes")],
-                None,
-                Err(ConfigureError::TokenRequired),
-            ),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "yes"), ("LOGFIRE_TOKEN", "a")],
-                None,
-                Ok(true),
-            ),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "if-token-present")],
-                None,
-                Ok(false),
-            ),
-            (
-                vec![
-                    ("LOGFIRE_SEND_TO_LOGFIRE", "if-token-present"),
-                    ("LOGFIRE_TOKEN", "a"),
-                ],
-                None,
-                Ok(true),
-            ),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no"), ("LOGFIRE_TOKEN", "a")],
-                Some(SendToLogfire::Yes),
-                Ok(true),
-            ),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no"), ("LOGFIRE_TOKEN", "a")],
-                Some(SendToLogfire::IfTokenPresent),
-                Ok(true),
-            ),
-            (
-                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no")],
-                Some(SendToLogfire::IfTokenPresent),
-                Ok(false),
-            ),
-        ] {
-            let env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
-
-            let mut config = crate::configure();
-            if let Some(value) = setting {
-                config = config.send_to_logfire(value);
-            }
-
-            let result = config
-                .build_parts(Some(&env))
-                .map(|parts| parts.send_to_logfire);
-
-            match (expected, result) {
-                (Ok(exp), Ok(actual)) => assert_eq!(exp, actual),
-                // compare strings because ConfigureError doesn't implement PartialEq
-                (Err(exp), Err(actual)) => assert_eq!(exp.to_string(), actual.to_string()),
-                (expected, result) => panic!("expected {expected:?}, got {result:?}"),
-            }
-        }
-    }
-}

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -1,0 +1,696 @@
+use std::{
+    backtrace::Backtrace,
+    borrow::Cow,
+    collections::HashMap,
+    panic::PanicHookInfo,
+    sync::{Arc, Once},
+    time::Duration,
+};
+
+use opentelemetry::{
+    logs::{LoggerProvider as _, Severity},
+    trace::TracerProvider,
+};
+use opentelemetry_sdk::{
+    logs::{BatchLogProcessor, SdkLoggerProvider},
+    metrics::{PeriodicReader, SdkMeterProvider},
+    trace::{BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider},
+};
+use tracing::{Subscriber, level_filters::LevelFilter, subscriber::DefaultGuard};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::{layer::SubscriberExt, registry::LookupSpan};
+
+use crate::{
+    __macros_impl::LogfireValue,
+    ConfigureError, LogfireConfigBuilder, ShutdownError,
+    bridges::tracing::LogfireTracingLayer,
+    config::{SendToLogfire, get_base_url_from_token},
+    internal::{
+        env::get_optional_env,
+        exporters::console::{ConsoleWriter, create_console_processors},
+        logfire_tracer::{GLOBAL_TRACER, LOCAL_TRACER, LogfireTracer},
+    },
+    ulid_id_generator::UlidIdGenerator,
+};
+
+/// A configured Logfire instance which contains configured `opentelemetry`, `tracing` and `log`
+/// integrations.
+///
+/// This instance is created by calling [`logfire::configure()`][crate::configure].
+#[derive(Clone)]
+pub struct Logfire {
+    pub(crate) tracer_provider: SdkTracerProvider,
+    pub(crate) tracer: LogfireTracer,
+    pub(crate) subscriber: Arc<dyn Subscriber + Send + Sync>,
+    pub(crate) meter_provider: SdkMeterProvider,
+    pub(crate) logger_provider: SdkLoggerProvider,
+    pub(crate) enable_tracing_metrics: bool,
+}
+
+impl Logfire {
+    /// Create a shutdown guard that will automatically shutdown Logfire when dropped.
+    ///
+    /// It is recommended to use this guard in the top level of your application to ensure
+    /// that Logfire is properly shut down even when exiting due to a panic.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let logfire = logfire::configure()
+    ///         .install_panic_handler()
+    /// #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
+    ///         .finish()?;
+    ///
+    ///     let guard = logfire.shutdown_guard();
+    ///
+    ///     logfire::info!("Hello world");
+    ///
+    ///     guard.shutdown()?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn shutdown_guard(self) -> ShutdownGuard {
+        ShutdownGuard {
+            logfire: Some(self),
+        }
+    }
+
+    /// Shuts down the Logfire instance.
+    ///
+    /// This will flush all data to the opentelemetry exporters and then close all
+    /// associated resources.
+    ///
+    /// # Errors
+    ///
+    /// See [`ConfigureError`] for possible errors.
+    pub fn shutdown(&self) -> Result<(), ShutdownError> {
+        self.tracer_provider.shutdown()?;
+        self.meter_provider.shutdown()?;
+        self.logger_provider.shutdown()?;
+        Ok(())
+    }
+
+    /// Get a tracing layer which can be used to embed this `Logfire` instance into a `tracing_subscriber::Registry`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tracing_subscriber::{Registry, layer::SubscriberExt};
+    ///
+    /// let logfire = logfire::configure()
+    ///    .local()  // use local mode to avoid setting global state
+    ///    .finish()
+    ///    .expect("Failed to configure logfire");
+    ///
+    /// let subscriber = tracing_subscriber::registry()
+    ///    .with(logfire.tracing_layer());
+    ///
+    /// tracing::subscriber::set_global_default(subscriber)
+    ///    .expect("Failed to set global subscriber");
+    ///
+    /// logfire::info!("Hello world");
+    ///
+    /// logfire.shutdown().expect("Failed to shutdown logfire");
+    /// ```
+    #[must_use]
+    pub fn tracing_layer<S>(&self) -> LogfireTracingLayer<S>
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        LogfireTracingLayer::new(self.tracer.clone(), self.enable_tracing_metrics)
+    }
+
+    /// Called by `LogfireConfigBuilder::finish()`.
+    pub(crate) fn from_config_builder(
+        config: LogfireConfigBuilder,
+    ) -> Result<Logfire, ConfigureError> {
+        let LogfireParts {
+            local,
+            tracer,
+            subscriber,
+            tracer_provider,
+            meter_provider,
+            logger_provider,
+            enable_tracing_metrics,
+            ..
+        } = Self::build_parts(config, None)?;
+
+        if !local {
+            tracing::subscriber::set_global_default(subscriber.clone())?;
+            let logger = crate::bridges::log::LogfireLogger::init(tracer.clone());
+            log::set_logger(logger)?;
+            log::set_max_level(logger.max_level());
+
+            GLOBAL_TRACER
+                .set(tracer.clone())
+                .map_err(|_| ConfigureError::AlreadyConfigured)?;
+
+            let propagator = opentelemetry::propagation::TextMapCompositePropagator::new(vec![
+                Box::new(opentelemetry_sdk::propagation::TraceContextPropagator::new()),
+                Box::new(opentelemetry_sdk::propagation::BaggagePropagator::new()),
+            ]);
+            opentelemetry::global::set_text_map_propagator(propagator);
+
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
+        }
+
+        Ok(Logfire {
+            tracer_provider,
+            tracer,
+            subscriber,
+            meter_provider,
+            logger_provider,
+            enable_tracing_metrics,
+        })
+    }
+
+    #[expect(clippy::too_many_lines)]
+    fn build_parts(
+        config: LogfireConfigBuilder,
+        env: Option<&HashMap<String, String>>,
+    ) -> Result<LogfireParts, ConfigureError> {
+        let mut token = config.token;
+        if token.is_none() {
+            token = get_optional_env("LOGFIRE_TOKEN", env)?;
+        }
+
+        let send_to_logfire = match config.send_to_logfire {
+            Some(send_to_logfire) => send_to_logfire,
+            None => match get_optional_env("LOGFIRE_SEND_TO_LOGFIRE", env)? {
+                Some(value) => value.parse()?,
+                None => SendToLogfire::Yes,
+            },
+        };
+
+        let send_to_logfire = match send_to_logfire {
+            SendToLogfire::Yes => true,
+            SendToLogfire::IfTokenPresent => token.is_some(),
+            SendToLogfire::No => false,
+        };
+
+        let advanced_options = config.advanced.unwrap_or_default();
+
+        let mut tracer_provider_builder = SdkTracerProvider::builder();
+        let mut logger_provider_builder = SdkLoggerProvider::builder();
+
+        if let Some(id_generator) = advanced_options.id_generator {
+            tracer_provider_builder = tracer_provider_builder.with_id_generator(id_generator);
+        } else {
+            tracer_provider_builder =
+                tracer_provider_builder.with_id_generator(UlidIdGenerator::new());
+        }
+
+        if let Some(resource) = advanced_options.resource.clone() {
+            tracer_provider_builder = tracer_provider_builder.with_resource(resource);
+        }
+
+        let mut http_headers: Option<HashMap<String, String>> = None;
+
+        let logfire_base_url = if send_to_logfire {
+            let Some(token) = token else {
+                return Err(ConfigureError::TokenRequired);
+            };
+
+            http_headers
+                .get_or_insert_default()
+                .insert("Authorization".to_string(), format!("Bearer {token}"));
+
+            Some(
+                advanced_options
+                    .base_url
+                    .as_deref()
+                    .unwrap_or_else(|| get_base_url_from_token(&token)),
+            )
+        } else {
+            None
+        };
+
+        if let Some(logfire_base_url) = logfire_base_url {
+            tracer_provider_builder = tracer_provider_builder.with_span_processor(
+                BatchSpanProcessor::builder(crate::exporters::span_exporter(
+                    logfire_base_url,
+                    http_headers.clone(),
+                )?)
+                .with_batch_config(
+                    BatchConfigBuilder::default()
+                        .with_scheduled_delay(Duration::from_millis(500)) // 500 matches Python
+                        .build(),
+                )
+                .build(),
+            );
+        }
+
+        let console_processors = config
+            .console_options
+            .map(|o| create_console_processors(Arc::new(ConsoleWriter::new(o))));
+
+        if let Some((span_processor, log_processor)) = console_processors {
+            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+            logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
+        }
+
+        for span_processor in config.additional_span_processors {
+            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+        }
+
+        let tracer_provider = tracer_provider_builder.build();
+
+        let tracer = tracer_provider.tracer("logfire");
+        let default_level_filter = config.default_level_filter.unwrap_or(if send_to_logfire {
+            // by default, send everything to the logfire platform, for best UX
+            LevelFilter::TRACE
+        } else {
+            // but if printing locally, just set INFO
+            LevelFilter::INFO
+        });
+
+        let filter = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(default_level_filter.into())
+            .from_env()?; // but allow the user to override this with `RUST_LOG`
+
+        let subscriber = tracing_subscriber::registry().with(filter);
+
+        let mut meter_provider_builder = SdkMeterProvider::builder();
+
+        if let Some(logfire_base_url) = logfire_base_url {
+            if config.metrics.is_some() {
+                let metric_reader = PeriodicReader::builder(crate::exporters::metric_exporter(
+                    logfire_base_url,
+                    http_headers.clone(),
+                )?)
+                .build();
+
+                meter_provider_builder = meter_provider_builder.with_reader(metric_reader);
+            }
+        }
+
+        if let Some(metrics) = config.metrics {
+            for reader in metrics.additional_readers {
+                meter_provider_builder = meter_provider_builder.with_reader(reader);
+            }
+        }
+
+        if let Some(resource) = advanced_options.resource.clone() {
+            meter_provider_builder = meter_provider_builder.with_resource(resource);
+        }
+
+        let meter_provider = meter_provider_builder.build();
+
+        if let Some(logfire_base_url) = logfire_base_url {
+            logger_provider_builder = logger_provider_builder.with_log_processor(
+                BatchLogProcessor::builder(crate::exporters::log_exporter(
+                    logfire_base_url,
+                    http_headers.clone(),
+                )?)
+                .build(),
+            );
+        }
+
+        for log_processor in advanced_options.log_record_processors {
+            logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
+        }
+
+        if let Some(resource) = advanced_options.resource {
+            logger_provider_builder = logger_provider_builder.with_resource(resource);
+        }
+
+        let logger_provider = logger_provider_builder.build();
+
+        let logger = Arc::new(logger_provider.logger("logfire"));
+
+        let mut filter_builder = env_filter::Builder::new();
+        if let Ok(filter) = std::env::var("RUST_LOG") {
+            filter_builder.parse(&filter);
+        } else {
+            filter_builder.parse(&default_level_filter.to_string());
+        }
+
+        let tracer = LogfireTracer {
+            inner: tracer,
+            meter_provider: meter_provider.clone(),
+            logger,
+            handle_panics: config.install_panic_handler,
+            filter: Arc::new(filter_builder.build()),
+        };
+
+        let subscriber = subscriber.with(LogfireTracingLayer::new(
+            tracer.clone(),
+            advanced_options.enable_tracing_metrics,
+        ));
+
+        if config.install_panic_handler {
+            install_panic_handler();
+        }
+
+        Ok(LogfireParts {
+            local: config.local,
+            tracer,
+            subscriber: Arc::new(subscriber),
+            tracer_provider,
+            meter_provider,
+            logger_provider,
+            enable_tracing_metrics: advanced_options.enable_tracing_metrics,
+            #[cfg(test)]
+            send_to_logfire,
+        })
+    }
+}
+
+/// A guard that automatically shuts down Logfire when dropped.
+///
+/// Create this guard by calling [`Logfire::shutdown_guard()`] to ensure clean shutdown
+/// when the guard goes out of scope.
+#[must_use = "this should be kept alive until logging should be stopped"]
+pub struct ShutdownGuard {
+    logfire: Option<Logfire>,
+}
+
+impl ShutdownGuard {
+    /// Shutdown the Logfire instance.
+    ///
+    /// This will flush all spans and metrics to the exporter.
+    ///
+    /// # Errors
+    ///
+    /// See [`ShutdownError`] for possible errors.
+    pub fn shutdown(mut self) -> Result<(), ShutdownError> {
+        self.shutdown_inner()
+    }
+
+    fn shutdown_inner(&mut self) -> Result<(), ShutdownError> {
+        if let Some(logfire) = self.logfire.take() {
+            logfire.shutdown()?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(clippy::print_stderr)]
+impl Drop for ShutdownGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.shutdown_inner() {
+            eprintln!("failed to shutdown logfire cleanly: {error:#?}");
+        }
+    }
+}
+
+struct LogfireParts {
+    local: bool,
+    tracer: LogfireTracer,
+    subscriber: Arc<dyn Subscriber + Send + Sync>,
+    tracer_provider: SdkTracerProvider,
+    meter_provider: SdkMeterProvider,
+    logger_provider: SdkLoggerProvider,
+    enable_tracing_metrics: bool,
+    #[cfg(test)]
+    send_to_logfire: bool,
+}
+
+/// Install `handler` as part of a chain of panic handlers.
+fn install_panic_handler() {
+    fn panic_hook(info: &PanicHookInfo) {
+        LogfireTracer::try_with(|tracer| {
+            if !tracer.handle_panics {
+                // this tracer is not handling panics
+                return;
+            }
+
+            let message = if let Some(s) = info.payload().downcast_ref::<&str>() {
+                s
+            } else if let Some(s) = info.payload().downcast_ref::<String>() {
+                s
+            } else {
+                ""
+            };
+
+            let location = info.location();
+            tracer.export_log(
+                None,
+                &tracing::Span::current().context(),
+                format!("panic: {message}"),
+                Severity::Error,
+                crate::__json_schema!(backtrace),
+                location.map(|l| Cow::Owned(l.file().to_string())),
+                location.map(std::panic::Location::line),
+                None,
+                [LogfireValue::new(
+                    "backtrace",
+                    Some(Backtrace::capture().to_string().into()),
+                )],
+            );
+        });
+    }
+
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            panic_hook(info);
+            prev(info);
+        }));
+    });
+}
+
+/// Helper for installing a logfire guard locally to a thread.
+///
+/// FIXME: This is still a bit of a mess, it's only implemented far enough to make tests pass...
+#[doc(hidden)]
+pub struct LocalLogfireGuard {
+    prior: Option<LogfireTracer>,
+    #[expect(dead_code, reason = "tracing RAII guard")]
+    tracing_guard: DefaultGuard,
+    logfire: Logfire,
+}
+
+impl LocalLogfireGuard {
+    /// Get the current tracer.
+    #[must_use]
+    pub fn subscriber(&self) -> Arc<dyn Subscriber + Send + Sync> {
+        self.logfire.subscriber.clone()
+    }
+
+    /// Get the current meter provider
+    #[must_use]
+    pub fn meter_provider(&self) -> &SdkMeterProvider {
+        &self.logfire.meter_provider
+    }
+
+    /// Convenience function to release this guard and shutdown Logfire.
+    pub fn shutdown(self) -> Result<(), ShutdownError> {
+        let logfire = self.logfire.clone();
+        drop(self); // ensure the guard is dropped before shutdown
+        logfire.shutdown()
+    }
+}
+
+impl Drop for LocalLogfireGuard {
+    fn drop(&mut self) {
+        // FIXME: if drop order is not consistent with creation order, does this create strange
+        // state?
+        LOCAL_TRACER.with_borrow_mut(|local_logfire| {
+            *local_logfire = self.prior.take();
+        });
+    }
+}
+
+#[doc(hidden)] // used in tests
+#[must_use]
+pub fn set_local_logfire(logfire: Logfire) -> LocalLogfireGuard {
+    let prior =
+        LOCAL_TRACER.with_borrow_mut(|local_logfire| local_logfire.replace(logfire.tracer.clone()));
+
+    let tracing_guard = tracing::subscriber::set_default(logfire.subscriber.clone());
+
+    // TODO: metrics??
+
+    LocalLogfireGuard {
+        prior,
+        tracing_guard,
+        logfire,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use crate::{ConfigureError, Logfire, config::SendToLogfire, configure};
+    use opentelemetry_sdk::trace::{SpanData, SpanProcessor};
+
+    #[test]
+    fn test_send_to_logfire() {
+        for (env, setting, expected) in [
+            (vec![], None, Err(ConfigureError::TokenRequired)),
+            (vec![("LOGFIRE_TOKEN", "a")], None, Ok(true)),
+            (vec![("LOGFIRE_SEND_TO_LOGFIRE", "no")], None, Ok(false)),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "yes")],
+                None,
+                Err(ConfigureError::TokenRequired),
+            ),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "yes"), ("LOGFIRE_TOKEN", "a")],
+                None,
+                Ok(true),
+            ),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "if-token-present")],
+                None,
+                Ok(false),
+            ),
+            (
+                vec![
+                    ("LOGFIRE_SEND_TO_LOGFIRE", "if-token-present"),
+                    ("LOGFIRE_TOKEN", "a"),
+                ],
+                None,
+                Ok(true),
+            ),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no"), ("LOGFIRE_TOKEN", "a")],
+                Some(SendToLogfire::Yes),
+                Ok(true),
+            ),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no"), ("LOGFIRE_TOKEN", "a")],
+                Some(SendToLogfire::IfTokenPresent),
+                Ok(true),
+            ),
+            (
+                vec![("LOGFIRE_SEND_TO_LOGFIRE", "no")],
+                Some(SendToLogfire::IfTokenPresent),
+                Ok(false),
+            ),
+        ] {
+            let env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+
+            let mut config = crate::configure();
+            if let Some(value) = setting {
+                config = config.send_to_logfire(value);
+            }
+
+            let result =
+                Logfire::build_parts(config, Some(&env)).map(|parts| parts.send_to_logfire);
+
+            match (expected, result) {
+                (Ok(exp), Ok(actual)) => assert_eq!(exp, actual),
+                // compare strings because ConfigureError doesn't implement PartialEq
+                (Err(exp), Err(actual)) => assert_eq!(exp.to_string(), actual.to_string()),
+                (expected, result) => panic!("expected {expected:?}, got {result:?}"),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestShutdownProcessor {
+        shutdown_called: Arc<AtomicBool>,
+    }
+
+    impl SpanProcessor for TestShutdownProcessor {
+        fn on_start(&self, _: &mut opentelemetry_sdk::trace::Span, _: &opentelemetry::Context) {}
+
+        fn on_end(&self, _: SpanData) {}
+
+        fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+            Ok(())
+        }
+
+        fn shutdown_with_timeout(&self, _: Duration) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.shutdown_called.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_shutdown_guard_drop() {
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+
+        {
+            let logfire = configure()
+                .local()
+                .send_to_logfire(false)
+                .with_additional_span_processor(TestShutdownProcessor {
+                    shutdown_called: shutdown_called.clone(),
+                })
+                .finish()
+                .unwrap();
+
+            let _guard = logfire.shutdown_guard();
+
+            // Guard is alive here, shutdown should not have been called
+            assert!(!shutdown_called.load(Ordering::Relaxed));
+        }
+
+        // Guard is dropped here, shutdown should be called
+        assert!(shutdown_called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_drop_multiple_shutdown_guard() {
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+
+        let logfire = configure()
+            .local()
+            .send_to_logfire(false)
+            .with_additional_span_processor(TestShutdownProcessor {
+                shutdown_called: shutdown_called.clone(),
+            })
+            .finish()
+            .unwrap();
+
+        // Having multiple shutdown guards should not cause issues when they are dropped
+        {
+            let _guard1 = logfire.clone().shutdown_guard();
+            let _guard2 = logfire.shutdown_guard();
+
+            // Guards are alive here, shutdown should not have been called
+            assert!(!shutdown_called.load(Ordering::Relaxed));
+        }
+
+        // Guards have been dropped, shutdown should be called
+        assert!(shutdown_called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_manual_shutdown() {
+        let shutdown_called = Arc::new(AtomicBool::new(false));
+
+        let logfire = configure()
+            .local()
+            .send_to_logfire(false)
+            .with_additional_span_processor(TestShutdownProcessor {
+                shutdown_called: shutdown_called.clone(),
+            })
+            .finish()
+            .unwrap();
+
+        // Not shutdown yet
+        assert!(!shutdown_called.load(Ordering::Relaxed));
+
+        // Manual shutdown should work
+        logfire.shutdown().expect("shutdown should succeed");
+
+        // Shutdown should have been called
+        assert!(shutdown_called.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    #[should_panic(expected = "OtelError(AlreadyShutdown)")]
+    fn test_multiple_shutdown_calls() {
+        let logfire = configure().local().send_to_logfire(false).finish().unwrap();
+
+        // First shutdown call should succeed
+        logfire.shutdown().expect("first shutdown should succeed");
+
+        // Second shutdown will fail
+        logfire.shutdown().unwrap();
+    }
+}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -283,7 +283,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::ERROR)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -292,14 +292,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::error!("Test error message");
             crate::error!("Test error with value", field = 42);
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -317,7 +317,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::WARN)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -326,14 +326,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::warn!("Test warn message");
             crate::warn!("Test warn with value", field = "test");
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -351,7 +351,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::INFO)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -360,14 +360,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::info!("Test info message");
             crate::info!("Test info with value", field = true);
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -385,7 +385,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::TRACE)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -394,14 +394,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::debug!("Test debug message");
             crate::debug!("Test debug with value", field = 3.14);
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -419,7 +419,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::TRACE)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -428,14 +428,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::trace!("Test trace message");
             crate::trace!("Test trace with value", field = "debug_info");
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -453,7 +453,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::INFO)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -462,14 +462,14 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire);
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             crate::log!(Level::INFO, "Test log message");
             crate::log!(Level::INFO, "Test log with value", field = "explicit");
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();
@@ -487,7 +487,7 @@ mod tests {
             ..ConsoleOptions::default().with_min_log_level(Level::INFO)
         };
 
-        let handler = crate::configure()
+        let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
@@ -496,7 +496,7 @@ mod tests {
             .finish()
             .unwrap();
 
-        let guard = crate::set_local_logfire(handler);
+        let guard = crate::set_local_logfire(logfire.clone());
 
         tracing::subscriber::with_default(guard.subscriber().clone(), || {
             let parent_span = crate::span!("parent span");
@@ -504,7 +504,7 @@ mod tests {
             crate::error!(parent: &parent_span, "Test error with parent", field = "parent_test");
         });
 
-        guard.shutdown_handler.shutdown().unwrap();
+        guard.shutdown().unwrap();
 
         let output = output.lock().unwrap();
         let output = std::str::from_utf8(&output).unwrap();

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -37,7 +37,7 @@ fn test_basic_span() {
     let exporter = InMemorySpanExporterBuilder::new().build();
     let log_exporter = InMemoryLogExporter::default();
 
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .local()
         .send_to_logfire(false)
         .with_additional_span_processor(SimpleSpanProcessor::new(DeterministicExporter::new(
@@ -60,7 +60,7 @@ fn test_basic_span() {
         .finish()
         .unwrap();
 
-    let guard = logfire::set_local_logfire(handler);
+    let guard = logfire::set_local_logfire(logfire);
 
     let value = 42;
 
@@ -1584,7 +1584,7 @@ async fn test_basic_metrics() {
             .build(),
     );
 
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .send_to_logfire(false)
         .with_metrics(Some(
             MetricsOptions::default().with_additional_reader(reader.clone()),
@@ -1596,7 +1596,7 @@ async fn test_basic_metrics() {
         .finish()
         .unwrap();
 
-    let guard = logfire::set_local_logfire(handler.clone());
+    let guard = logfire::set_local_logfire(logfire.clone());
 
     use opentelemetry::metrics::MeterProvider;
 
@@ -1612,7 +1612,7 @@ async fn test_basic_metrics() {
     counter.add(2, &[]);
     reader.export(&mut exporter).await;
 
-    handler.shutdown().unwrap();
+    logfire.shutdown().unwrap();
 
     let metrics = exporter.get_finished_metrics().unwrap();
 

--- a/tests/test_log_attributes.rs
+++ b/tests/test_log_attributes.rs
@@ -12,7 +12,7 @@ use tracing::Level;
 #[test]
 fn test_log_macro_attributes() {
     let log_exporter = InMemoryLogExporter::default();
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .local()
         .send_to_logfire(false)
         .with_advanced_options(
@@ -21,7 +21,7 @@ fn test_log_macro_attributes() {
         )
         .finish()
         .unwrap();
-    let guard = logfire::set_local_logfire(handler);
+    let guard = logfire::set_local_logfire(logfire);
 
     tracing::subscriber::with_default(guard.subscriber(), || {
         let _ = log!(Level::INFO, "string_attr_log", foo = "bar");
@@ -96,7 +96,7 @@ fn test_log_macro_shorthand_ident() {
     };
 
     let log_exporter = InMemoryLogExporter::default();
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .local()
         .send_to_logfire(false)
         .with_advanced_options(
@@ -106,7 +106,7 @@ fn test_log_macro_shorthand_ident() {
         .finish()
         .unwrap();
 
-    let guard = logfire::set_local_logfire(handler);
+    let guard = logfire::set_local_logfire(logfire);
     tracing::subscriber::with_default(guard.subscriber(), || {
         let _ = log!(Level::INFO, "dotted_attr_log", dotted.key);
         let _ = log!(Level::INFO, "int_attr_log", int_val);

--- a/tests/test_span_attributes.rs
+++ b/tests/test_span_attributes.rs
@@ -11,7 +11,7 @@ use test_utils::{find_attr, find_span};
 #[test]
 fn test_span_macro_attributes() {
     let exporter = InMemorySpanExporterBuilder::new().build();
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .local()
         .send_to_logfire(false)
         .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
@@ -19,7 +19,7 @@ fn test_span_macro_attributes() {
         ))
         .finish()
         .unwrap();
-    let guard = logfire::set_local_logfire(handler);
+    let guard = logfire::set_local_logfire(logfire);
 
     tracing::subscriber::with_default(guard.subscriber(), || {
         let _ = span!("string_attr_span", foo = "bar");
@@ -87,7 +87,7 @@ fn test_span_macro_shorthand_ident() {
     };
 
     let exporter = InMemorySpanExporterBuilder::new().build();
-    let handler = logfire::configure()
+    let logfire = logfire::configure()
         .local()
         .send_to_logfire(false)
         .with_additional_span_processor(opentelemetry_sdk::trace::SimpleSpanProcessor::new(
@@ -95,7 +95,7 @@ fn test_span_macro_shorthand_ident() {
         ))
         .finish()
         .unwrap();
-    let guard = logfire::set_local_logfire(handler);
+    let guard = logfire::set_local_logfire(logfire);
     tracing::subscriber::with_default(guard.subscriber(), || {
         let _ = span!("dotted_attr_span", dotted.key);
         let _ = span!("int_attr_span", int_val);


### PR DESCRIPTION
This changes the result of calling `logfire::configure().finish()` to produce a `Logfire` struct.

The on-drop-shutdown semantics are moved to a `ShutdownGuard` type, which is accessible by calling `logfire.shutdown_guard()` on a `Logfire` struct.

I think this cleans up the public API and makes it possible to be deliberate about where to install the guard. The previous `ShutdownHandler` type was doing too many things.

As part of this cleanup I've moved a lot of code out of `lib.rs` and into either `config.rs` or a new `logfire.rs` file.