### PR TITLE
allow picking up credentials from a `.logfire` directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing-opentelemetry = "0.31"
 thiserror = "2"
 
 serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 nu-ansi-term = "0.50.1"
 chrono = "0.4.39"
 regex = "1.11.1"
@@ -53,10 +54,11 @@ opentelemetry-instrumentation-actix-web = { version = "0.22", features = ["metri
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = "0.3"
+tempfile = "3.20.0"
 
 [features]
-default = ["export-http-protobuf"]
-serde = ["dep:serde"]
+default = ["data-dir", "export-http-protobuf"]
+data-dir = ["dep:serde", "dep:serde_json"]
 export-grpc = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/tls", "dep:http", "dep:tonic"]
 export-http-protobuf = ["opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
 export-http-json = ["opentelemetry-otlp/http-json", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The Logfire server application for recording and displaying data is closed sourc
 
 ## Using Logfire's Rust SDK
 
-First [set up a Logfire project](https://logfire.pydantic.dev/docs/#logfire) and [create a write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/). You'll need to set this token as an environment variable (`LOGFIRE_TOKEN`) to export to Logfire.
+First [set up a Logfire project](https://logfire.pydantic.dev/docs/#logfire). You will then configure the SDK to send to Logfire by:
+- [creating a write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/) manually and setting this token as an environment variable (`LOGFIRE_TOKEN`), or
+- [using the Logfire CLI](https://logfire.pydantic.dev/docs/#instrument) to select a project.
 
 With a logfire project set up, start by adding the `logfire` crate to your `Cargo.toml`:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 
 use std::{
     fmt::Display,
+    path::PathBuf,
     str::FromStr,
     sync::{Arc, Mutex},
 };
@@ -31,7 +32,7 @@ pub struct LogfireConfigBuilder {
     pub(crate) console_options: Option<ConsoleOptions>,
 
     // config_dir: Option<PathBuf>,
-    // data_dir: Option<Path>,
+    pub(crate) data_dir: Option<PathBuf>,
 
     // TODO: change to match Python SDK
     pub(crate) additional_span_processors: Vec<BoxedSpanProcessor>,
@@ -90,6 +91,13 @@ impl LogfireConfigBuilder {
     /// If not set, will use `ConsoleOptions::default()`.
     pub fn with_console(mut self, console_options: Option<ConsoleOptions>) -> Self {
         self.console_options = console_options;
+        self
+    }
+
+    /// Sets the directory where credentials are stored. If unset uses the `LOGFIRE_CREDENTIALS_DIR` environment
+    /// variable, otherwise defaults to `'.logfire'`.
+    pub fn with_data_dir<T: Into<PathBuf>>(mut self, data_dir: T) -> Self {
+        self.data_dir = Some(data_dir.into());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,15 @@ pub enum ConfigureError {
         value: String,
     },
 
+    /// Error reading credentials file.
+    #[error("Error reading credentials file {path}: {error}")]
+    CredentialFileError {
+        /// The path to the credentials file.
+        path: std::path::PathBuf,
+        /// The underlying error.
+        error: String,
+    },
+
     /// Any other error.
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -811,7 +811,10 @@ mod tests {
         std::fs::write(&credentials_path, CREDENTIALS_JSON).unwrap();
 
         // Test that credentials are loaded when using with_data_dir
-        let config = crate::configure().local().with_data_dir(temp_dir.path());
+        let config = crate::configure()
+            .local()
+            .send_to_logfire(SendToLogfire::IfTokenPresent)
+            .with_data_dir(temp_dir.path());
 
         let md = Logfire::build_parts(config, None).unwrap().metadata;
 

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -7,6 +7,9 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "data-dir")]
+use std::path::{Path, PathBuf};
+
 use opentelemetry::{
     logs::{LoggerProvider as _, Severity},
     trace::TracerProvider,
@@ -166,6 +169,46 @@ impl Logfire {
         })
     }
 
+    /// Load token from credentials file if available.
+    #[cfg(feature = "data-dir")]
+    fn load_token_from_credentials_file(
+        data_dir: Option<&Path>,
+        env: Option<&HashMap<String, String>>,
+    ) -> Result<Option<LogfireCredentials>, ConfigureError> {
+        // Determine credentials directory
+        let credentials_dir = if let Some(dir) = data_dir {
+            Cow::Borrowed(dir)
+        } else if let Some(dir) = get_optional_env("LOGFIRE_CREDENTIALS_DIR", env)? {
+            Cow::Owned(PathBuf::from(dir))
+        } else {
+            // Default to .logfire in current directory
+            Cow::Borrowed(Path::new(".logfire"))
+        };
+
+        let credentials_path = credentials_dir.join("logfire_credentials.json");
+
+        // Return None if file doesn't exist (not an error)
+        if !credentials_path.exists() {
+            return Ok(None);
+        }
+
+        // Read and parse credentials file
+        let contents = std::fs::read_to_string(&credentials_path).map_err(|e| {
+            ConfigureError::CredentialFileError {
+                path: credentials_path.clone(),
+                error: e.to_string(),
+            }
+        })?;
+
+        match serde_json::from_str(&contents) {
+            Ok(credentials) => Ok(Some(credentials)),
+            Err(e) => Err(ConfigureError::CredentialFileError {
+                path: credentials_path.clone(),
+                error: format!("JSON parse error: {e}"),
+            }),
+        }
+    }
+
     #[expect(clippy::too_many_lines)]
     fn build_parts(
         config: LogfireConfigBuilder,
@@ -174,6 +217,25 @@ impl Logfire {
         let mut token = config.token;
         if token.is_none() {
             token = get_optional_env("LOGFIRE_TOKEN", env)?;
+        }
+
+        #[cfg_attr(
+            not(feature = "data-dir"),
+            expect(unused_mut, reason = "only mutated on data-dir feature")
+        )]
+        let mut advanced_options = config.advanced.unwrap_or_default();
+
+        // Try loading from credentials file if still no token
+        #[cfg(feature = "data-dir")]
+        if token.is_none() {
+            if let Some(credentials) =
+                Self::load_token_from_credentials_file(config.data_dir.as_deref(), env)?
+            {
+                token = Some(credentials.token);
+                advanced_options.base_url = advanced_options
+                    .base_url
+                    .or(Some(credentials.logfire_api_url));
+            }
         }
 
         let send_to_logfire = match config.send_to_logfire {
@@ -189,8 +251,6 @@ impl Logfire {
             SendToLogfire::IfTokenPresent => token.is_some(),
             SendToLogfire::No => false,
         };
-
-        let advanced_options = config.advanced.unwrap_or_default();
 
         let mut tracer_provider_builder = SdkTracerProvider::builder();
         let mut logger_provider_builder = SdkLoggerProvider::builder();
@@ -209,7 +269,7 @@ impl Logfire {
         let mut http_headers: Option<HashMap<String, String>> = None;
 
         let logfire_base_url = if send_to_logfire {
-            let Some(token) = token else {
+            let Some(token) = &token else {
                 return Err(ConfigureError::TokenRequired);
             };
 
@@ -221,7 +281,7 @@ impl Logfire {
                 advanced_options
                     .base_url
                     .as_deref()
-                    .unwrap_or_else(|| get_base_url_from_token(&token)),
+                    .unwrap_or_else(|| get_base_url_from_token(token)),
             )
         } else {
             None
@@ -353,7 +413,11 @@ impl Logfire {
             logger_provider,
             enable_tracing_metrics: advanced_options.enable_tracing_metrics,
             #[cfg(test)]
-            send_to_logfire,
+            metadata: TestMetadata {
+                send_to_logfire,
+                logfire_token: token,
+                logfire_base_url: logfire_base_url.map(str::to_string),
+            },
         })
     }
 }
@@ -405,7 +469,14 @@ struct LogfireParts {
     logger_provider: SdkLoggerProvider,
     enable_tracing_metrics: bool,
     #[cfg(test)]
+    metadata: TestMetadata,
+}
+
+#[cfg(test)]
+struct TestMetadata {
     send_to_logfire: bool,
+    logfire_token: Option<String>,
+    logfire_base_url: Option<String>,
 }
 
 /// Install `handler` as part of a chain of panic handlers.
@@ -512,6 +583,18 @@ pub fn set_local_logfire(logfire: Logfire) -> LocalLogfireGuard {
     }
 }
 
+/// Credentials stored in `logfire_credentials.json` files
+#[cfg(feature = "data-dir")]
+#[derive(serde::Deserialize)]
+struct LogfireCredentials {
+    token: String,
+    #[expect(dead_code, reason = "not used for now")]
+    project_name: String,
+    #[expect(dead_code, reason = "not used for now")]
+    project_url: String,
+    logfire_api_url: String,
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -571,15 +654,26 @@ mod tests {
                 Ok(false),
             ),
         ] {
-            let env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
+            let env: std::collections::HashMap<String, String> =
+                env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
 
             let mut config = crate::configure();
             if let Some(value) = setting {
                 config = config.send_to_logfire(value);
             }
 
-            let result =
-                Logfire::build_parts(config, Some(&env)).map(|parts| parts.send_to_logfire);
+            let md = Logfire::build_parts(config, Some(&env)).map(|parts| parts.metadata);
+
+            if let Ok(md) = &md {
+                assert!(!md.send_to_logfire || md.logfire_token.is_some());
+                assert!(
+                    !md.send_to_logfire
+                        || md.logfire_base_url.as_deref()
+                            == Some("https://logfire-us.pydantic.dev")
+                );
+            }
+
+            let result = md.as_ref().map(|md| md.send_to_logfire);
 
             match (expected, result) {
                 (Ok(exp), Ok(actual)) => assert_eq!(exp, actual),
@@ -698,5 +792,117 @@ mod tests {
 
         // Second `shutdown` call should fail
         logfire.shutdown().unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "data-dir")]
+    fn test_credentials_file_loading() {
+        const CREDENTIALS_JSON: &str = r#"{
+    "token": "test_token_123",
+    "project_name": "test-project",
+    "project_url": "https://logfire-eu.pydantic.dev/test-org/test-project",
+    "logfire_api_url": "https://test-api-url.com"
+}"#;
+
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+
+        // Write credentials file
+        let credentials_path = temp_dir.path().join("logfire_credentials.json");
+        std::fs::write(&credentials_path, CREDENTIALS_JSON).unwrap();
+
+        // Test that credentials are loaded when using with_data_dir
+        let config = crate::configure().local().with_data_dir(temp_dir.path());
+
+        let md = Logfire::build_parts(config, None).unwrap().metadata;
+
+        assert_eq!(md.send_to_logfire, true);
+        assert_eq!(md.logfire_token.as_deref(), Some("test_token_123"));
+        assert_eq!(
+            md.logfire_base_url.as_deref(),
+            Some("https://test-api-url.com")
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "data-dir")]
+    fn test_credentials_file_loading_env_var() {
+        const CREDENTIALS_JSON: &str = r#"{
+    "token": "test_token_123",
+    "project_name": "test-project",
+    "project_url": "https://logfire-eu.pydantic.dev/test-org/test-project",
+    "logfire_api_url": "https://test-api-url.com"
+}"#;
+
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+
+        // Write credentials file
+        let credentials_path = temp_dir.path().join("logfire_credentials.json");
+        std::fs::write(&credentials_path, CREDENTIALS_JSON).unwrap();
+
+        // Test that credentials are loaded when using with_data_dir
+        let config = crate::configure().local();
+
+        let env: std::collections::HashMap<String, String> = [(
+            "LOGFIRE_CREDENTIALS_DIR".to_string(),
+            temp_dir.path().display().to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let md = Logfire::build_parts(config, Some(&env)).unwrap().metadata;
+
+        assert_eq!(md.send_to_logfire, true);
+        assert_eq!(md.logfire_token.as_deref(), Some("test_token_123"));
+        assert_eq!(
+            md.logfire_base_url.as_deref(),
+            Some("https://test-api-url.com")
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "data-dir")]
+    fn test_credentials_file_error_handling() {
+        // Create a temporary directory using tempfile
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let credentials_path = temp_dir.path().join("logfire_credentials.json");
+
+        // Test with invalid JSON
+        std::fs::write(&credentials_path, "invalid json").unwrap();
+
+        let result = crate::configure()
+            .local()
+            .send_to_logfire(true) // This should require a token
+            .with_data_dir(temp_dir.path())
+            .finish();
+
+        // Should get a credential file error due to invalid JSON
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(
+                e,
+                crate::ConfigureError::CredentialFileError { .. }
+            ));
+        }
+        // temp_dir is cleaned up automatically
+    }
+
+    #[test]
+    #[cfg(feature = "data-dir")]
+    fn test_no_credentials_file_fallback() {
+        // Create a temporary directory without any credentials file using tempfile
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+
+        let result = crate::configure()
+            .local()
+            .send_to_logfire(true) // This should require a token
+            .with_data_dir(temp_dir.path())
+            .finish();
+
+        // Should get TokenRequired error since no credentials file exists
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, crate::ConfigureError::TokenRequired));
+        }
+        // temp_dir is cleaned up automatically
     }
 }


### PR DESCRIPTION
This makes the Rust SDK compatible with the `logfire projects use` command of the CLI, which writes the credentials to a `.logfire/logfire_credentials.json` file in the cwd.