### PR TITLE
add integration tests for trace export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ opentelemetry_sdk = { version = "0.30", default-features = false, features = ["t
 regex = "1.11.1"
 tokio = {version = "1.44.1", features = ["test-util", "macros", "rt-multi-thread"] }
 ulid = "1.2.0"
+wiremock = "0.6"
+tonic-build = "0.13"
+tonic = { version = "0.13", features = ["transport"] }
+prost = "0.13"
+opentelemetry-proto = { version = "0.30", features = ["tonic", "gen-tonic-messages"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 
 # Dependencies for examples
 axum = { version = "0.8", features = ["macros"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,7 +308,7 @@ impl std::fmt::Debug for Target {
     }
 }
 
-/// Options primarily used for testing by Logfire developers.
+/// Options used for fine-grained control over the logfire SDK.
 #[derive(Default)]
 pub struct AdvancedOptions {
     pub(crate) base_url: Option<String>,

--- a/src/exporters.rs
+++ b/src/exporters.rs
@@ -91,7 +91,7 @@ pub fn span_exporter(
                     use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
                     builder
                         .with_http()
-                        .with_protocol(Protocol::HttpBinary)
+                        .with_protocol(Protocol::HttpJson)
                         .with_headers(headers.unwrap_or_default())
                         .with_endpoint(format!("{endpoint}/v1/traces"))
                         .build()?
@@ -164,7 +164,7 @@ pub fn metric_exporter(
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
                 Ok(builder
                     .with_http()
-                    .with_protocol(Protocol::HttpBinary)
+                    .with_protocol(Protocol::HttpJson)
                     .with_headers(headers.unwrap_or_default())
                     .with_endpoint(format!("{endpoint}/v1/metrics"))
                     .build()?)
@@ -234,7 +234,7 @@ pub fn log_exporter(
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
                 Ok(builder
                     .with_http()
-                    .with_protocol(Protocol::HttpBinary)
+                    .with_protocol(Protocol::HttpJson)
                     .with_headers(headers.unwrap_or_default())
                     .with_endpoint(format!("{endpoint}/v1/logs"))
                     .build()?)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -407,7 +407,17 @@ pub fn make_trace_request_deterministic(req: &mut ExportTraceServiceRequest) {
     let mut timestamp_remap = TimestampRemapper::new();
 
     for resource_span in &mut req.resource_spans {
+        if let Some(resource) = &mut resource_span.resource {
+            // Sort attributes by key
+            resource.attributes.sort_by_key(|attr| attr.key.clone());
+        }
+
         for scope_span in &mut resource_span.scope_spans {
+            if let Some(scope) = &mut scope_span.scope {
+                // Sort attributes by key
+                scope.attributes.sort_by_key(|attr| attr.key.clone());
+            }
+
             for span in &mut scope_span.spans {
                 // Set start/end timestamps to deterministic values
                 span.start_time_unix_nano =

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,6 +16,7 @@ use opentelemetry::{
     logs::{LogRecord, Logger, LoggerProvider as _},
     trace::{SpanId, TraceId},
 };
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use opentelemetry_sdk::{
     Resource,
     error::OTelSdkResult,
@@ -166,6 +167,15 @@ impl TimestampRemapper {
             }
         }
     }
+
+    fn remap_u64_nano_timestamp(&mut self, from: u64) -> u64 {
+        self.remap_timestamp(SystemTime::UNIX_EPOCH + std::time::Duration::from_nanos(from))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .try_into()
+            .unwrap()
+    }
 }
 
 pub fn remap_timestamps_in_console_output(output: &str) -> Cow<'_, str> {
@@ -303,7 +313,7 @@ pub fn make_deterministic_logs(
     file: &str,
     line_offset: u32,
 ) -> Vec<LogDataWithResource> {
-    let timestamp_remap = Arc::new(Mutex::new(TimestampRemapper::new()));
+    let mut timestamp_remap = TimestampRemapper::new();
 
     // A new logger is necessary to be able to create log records; `SdkLogRecord` constructor is private.
     let logger_provider = SdkLoggerProvider::builder().build();
@@ -318,16 +328,11 @@ pub fn make_deterministic_logs(
 
             // Copy basic fields with deterministic timestamp remapping
             if let Some(timestamp) = original_record.timestamp() {
-                new_record
-                    .set_timestamp(timestamp_remap.lock().unwrap().remap_timestamp(timestamp));
+                new_record.set_timestamp(timestamp_remap.remap_timestamp(timestamp));
             }
             if let Some(observed_timestamp) = original_record.observed_timestamp() {
-                new_record.set_observed_timestamp(
-                    timestamp_remap
-                        .lock()
-                        .unwrap()
-                        .remap_timestamp(observed_timestamp),
-                );
+                new_record
+                    .set_observed_timestamp(timestamp_remap.remap_timestamp(observed_timestamp));
             }
             if let Some(event_name) = original_record.event_name() {
                 new_record.set_event_name(event_name);
@@ -396,4 +401,42 @@ pub fn make_deterministic_logs(
             }
         })
         .collect()
+}
+
+pub fn make_trace_request_deterministic(req: &mut ExportTraceServiceRequest) {
+    let mut timestamp_remap = TimestampRemapper::new();
+
+    for resource_span in &mut req.resource_spans {
+        for scope_span in &mut resource_span.scope_spans {
+            for span in &mut scope_span.spans {
+                // Set start/end timestamps to deterministic values
+                span.start_time_unix_nano =
+                    timestamp_remap.remap_u64_nano_timestamp(span.start_time_unix_nano);
+                span.end_time_unix_nano =
+                    timestamp_remap.remap_u64_nano_timestamp(span.end_time_unix_nano);
+
+                // Zero out non-deterministic attributes
+                for attr in &mut span.attributes {
+                    if attr.key == "thread.id" || attr.key == "busy_ns" || attr.key == "idle_ns" {
+                        attr.value = Some(opentelemetry_proto::tonic::common::v1::AnyValue {
+                            value: Some(
+                                opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(
+                                    0,
+                                ),
+                            ),
+                        });
+                    }
+                }
+
+                // Also sort attributes by key
+                span.attributes.sort_by_key(|attr| attr.key.clone());
+
+                // Set event timestamps to deterministic values
+                for event in &mut span.events {
+                    event.time_unix_nano =
+                        timestamp_remap.remap_u64_nano_timestamp(event.time_unix_nano);
+                }
+            }
+        }
+    }
 }

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -1,0 +1,391 @@
+//! Integration tests for gRPC sink with mock server.
+#![cfg(feature = "export-grpc")]
+
+use insta::assert_debug_snapshot;
+use logfire::{configure, set_local_logfire, span};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+use tonic::{Request, Response, Status, transport::Server};
+
+use crate::test_utils::{DeterministicIdGenerator, make_trace_request_deterministic};
+
+#[path = "../src/test_utils.rs"]
+mod test_utils;
+
+/// Mock trace service that captures requests for testing
+#[derive(Clone)]
+struct MockTraceService {
+    captured: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+}
+
+impl MockTraceService {
+    fn new(captured: Arc<Mutex<Vec<ExportTraceServiceRequest>>>) -> Self {
+        Self { captured }
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for MockTraceService {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        let trace_request = request.into_inner();
+
+        // Capture the request for testing
+        {
+            let mut captured = self.captured.lock().unwrap();
+            captured.push(trace_request);
+        }
+
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+/// Start a mock gRPC server and return its address
+async fn start_mock_grpc_server() -> (String, Arc<Mutex<Vec<ExportTraceServiceRequest>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let addr_str = format!("http://{}", addr);
+
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let captured_clone = captured.clone();
+
+    let trace_service = MockTraceService::new(captured_clone);
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(TraceServiceServer::new(trace_service))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .expect("gRPC server failed to start");
+    });
+
+    let channel = tonic::transport::Channel::from_shared(addr_str.clone())
+        .unwrap()
+        .connect()
+        .await
+        .expect("Failed to connect to mock gRPC server");
+
+    tonic::client::Grpc::new(channel).ready().await.unwrap();
+
+    (addr_str, captured)
+}
+
+/// Test gRPC protobuf export infrastructure
+#[tokio::test]
+async fn test_grpc_protobuf_export() {
+    use logfire::config::AdvancedOptions;
+
+    let (server_addr, captured) = start_mock_grpc_server().await;
+
+    let env_guard = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Holding mutex to prevent other threads interacting with env
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+    }
+
+    let logfire = configure()
+        .local()
+        .send_to_logfire(true)
+        .with_token("test-token")
+        .with_advanced_options(
+            AdvancedOptions::default()
+                .with_base_url(server_addr)
+                .with_id_generator(DeterministicIdGenerator::new()),
+        )
+        .finish()
+        .unwrap();
+
+    // SAFETY: As above
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+    }
+    drop(env_guard);
+
+    let guard = set_local_logfire(logfire);
+    span!("grpc_test_span").in_scope(|| {});
+    tokio::task::spawn_blocking(move || guard.shutdown())
+        .await
+        .unwrap()
+        .unwrap();
+
+    let requests = captured.lock().unwrap();
+
+    assert_eq!(requests.len(), 1);
+
+    let mut body = requests[0].clone();
+    make_trace_request_deterministic(&mut body);
+
+    assert_debug_snapshot!(body, @r#"
+    ExportTraceServiceRequest {
+        resource_spans: [
+            ResourceSpans {
+                resource: Some(
+                    Resource {
+                        attributes: [
+                            KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.language",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "rust",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "opentelemetry",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.version",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "0.30.0",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        dropped_attributes_count: 0,
+                        entity_refs: [],
+                    },
+                ),
+                scope_spans: [
+                    ScopeSpans {
+                        scope: Some(
+                            InstrumentationScope {
+                                name: "logfire",
+                                version: "",
+                                attributes: [],
+                                dropped_attributes_count: 0,
+                            },
+                        ),
+                        spans: [
+                            Span {
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                trace_state: "",
+                                parent_span_id: [],
+                                flags: 1,
+                                name: "grpc_test_span",
+                                kind: Internal,
+                                start_time_unix_nano: 0,
+                                end_time_unix_nano: 1000000000,
+                                attributes: [
+                                    KeyValue {
+                                        key: "busy_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tests/test_grpc_sink.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        113,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_sink",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "idle_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{\"type\":\"object\",\"properties\":{}}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.level_num",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        9,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.msg",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "grpc_test_span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.span_type",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                events: [],
+                                dropped_events_count: 0,
+                                links: [],
+                                dropped_links_count: 0,
+                                status: Some(
+                                    Status {
+                                        message: "",
+                                        code: Unset,
+                                    },
+                                ),
+                            },
+                        ],
+                        schema_url: "",
+                    },
+                ],
+                schema_url: "",
+            },
+        ],
+    }
+    "#);
+}
+
+/// Mutex to avoid concurrent mutation of env vars.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/tests/test_http_sink.rs
+++ b/tests/test_http_sink.rs
@@ -1,0 +1,649 @@
+//! Integration tests for HTTP sink with mock server.
+
+use logfire::config::AdvancedOptions;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use insta::assert_debug_snapshot;
+use logfire::{configure, set_local_logfire, span};
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use prost::Message;
+
+use crate::test_utils::{DeterministicIdGenerator, make_trace_request_deterministic};
+
+#[path = "../src/test_utils.rs"]
+mod test_utils;
+
+/// Test HTTP protobuf export infrastructure
+#[tokio::test]
+async fn test_http_protobuf_export() {
+    let mock_server = MockServer::start().await;
+
+    let traces_mock = Mock::given(method("POST"))
+        .and(path("/v1/traces"))
+        .and(header("content-type", "application/x-protobuf"))
+        .and(header("authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200));
+
+    mock_server.register(traces_mock).await;
+
+    let env_guard = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Holding mutex to prevent other thread interacting with env
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf");
+    }
+
+    let logfire = configure()
+        .local()
+        .send_to_logfire(true)
+        .with_token("test-token")
+        .with_advanced_options(
+            AdvancedOptions::default()
+                .with_base_url(mock_server.uri())
+                .with_id_generator(DeterministicIdGenerator::new()),
+        )
+        .finish()
+        .unwrap();
+
+    // SAFETY: As above
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+    }
+    drop(env_guard);
+
+    let guard = set_local_logfire(logfire);
+    span!("test_span").in_scope(|| {});
+    guard.shutdown().unwrap();
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+
+    assert_eq!(request.method.as_str(), "POST");
+    assert_eq!(request.url.path(), "/v1/traces");
+    let mut body = ExportTraceServiceRequest::decode(request.body.as_slice())
+        .expect("failed to decode trace request");
+    make_trace_request_deterministic(&mut body);
+
+    assert_debug_snapshot!(body, @r#"
+    ExportTraceServiceRequest {
+        resource_spans: [
+            ResourceSpans {
+                resource: Some(
+                    Resource {
+                        attributes: [
+                            KeyValue {
+                                key: "telemetry.sdk.language",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "rust",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "opentelemetry",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.version",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "0.30.0",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        dropped_attributes_count: 0,
+                        entity_refs: [],
+                    },
+                ),
+                scope_spans: [
+                    ScopeSpans {
+                        scope: Some(
+                            InstrumentationScope {
+                                name: "logfire",
+                                version: "",
+                                attributes: [],
+                                dropped_attributes_count: 0,
+                            },
+                        ),
+                        spans: [
+                            Span {
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                trace_state: "",
+                                parent_span_id: [],
+                                flags: 1,
+                                name: "test_span",
+                                kind: Internal,
+                                start_time_unix_nano: 0,
+                                end_time_unix_nano: 1000000000,
+                                attributes: [
+                                    KeyValue {
+                                        key: "busy_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tests/test_http_sink.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        55,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_http_sink",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "idle_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{\"type\":\"object\",\"properties\":{}}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.level_num",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        9,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.msg",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.span_type",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_http_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                events: [],
+                                dropped_events_count: 0,
+                                links: [],
+                                dropped_links_count: 0,
+                                status: Some(
+                                    Status {
+                                        message: "",
+                                        code: Unset,
+                                    },
+                                ),
+                            },
+                        ],
+                        schema_url: "",
+                    },
+                ],
+                schema_url: "",
+            },
+        ],
+    }
+    "#);
+}
+
+/// Test HTTP JSON export to mock server
+#[tokio::test]
+async fn test_http_json_export() {
+    let mock_server = MockServer::start().await;
+
+    let traces_mock = Mock::given(method("POST"))
+        .and(path("/v1/traces"))
+        .and(header("content-type", "application/json"))
+        .and(header("authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200));
+
+    mock_server.register(traces_mock).await;
+
+    let env_guard = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Holding mutex to prevent other thread interacting with env
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json");
+    }
+
+    let logfire = configure()
+        .local()
+        .send_to_logfire(true)
+        .with_token("test-token")
+        .with_advanced_options(
+            AdvancedOptions::default()
+                .with_base_url(mock_server.uri())
+                .with_id_generator(DeterministicIdGenerator::new()),
+        )
+        .finish()
+        .unwrap();
+
+    // SAFETY: As above
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+    }
+    drop(env_guard);
+
+    let guard = set_local_logfire(logfire);
+    span!("json_test_span").in_scope(|| {});
+    guard.shutdown().unwrap();
+
+    let requests = mock_server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+
+    assert_eq!(request.method.as_str(), "POST");
+    assert_eq!(request.url.path(), "/v1/traces");
+    let mut body: ExportTraceServiceRequest =
+        serde_json::from_slice(&request.body).expect("failed to decode trace request");
+
+    make_trace_request_deterministic(&mut body);
+
+    assert_debug_snapshot!(body, @r#"
+    ExportTraceServiceRequest {
+        resource_spans: [
+            ResourceSpans {
+                resource: Some(
+                    Resource {
+                        attributes: [
+                            KeyValue {
+                                key: "telemetry.sdk.language",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "rust",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "opentelemetry",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.version",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "0.30.0",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        dropped_attributes_count: 0,
+                        entity_refs: [],
+                    },
+                ),
+                scope_spans: [
+                    ScopeSpans {
+                        scope: Some(
+                            InstrumentationScope {
+                                name: "logfire",
+                                version: "",
+                                attributes: [],
+                                dropped_attributes_count: 0,
+                            },
+                        ),
+                        spans: [
+                            Span {
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                trace_state: "",
+                                parent_span_id: [],
+                                flags: 1,
+                                name: "json_test_span",
+                                kind: Internal,
+                                start_time_unix_nano: 0,
+                                end_time_unix_nano: 1000000000,
+                                attributes: [
+                                    KeyValue {
+                                        key: "busy_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tests/test_http_sink.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        370,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_http_sink",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "idle_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{\"type\":\"object\",\"properties\":{}}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.level_num",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        9,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.msg",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "json_test_span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.span_type",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_http_json_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                events: [],
+                                dropped_events_count: 0,
+                                links: [],
+                                dropped_links_count: 0,
+                                status: Some(
+                                    Status {
+                                        message: "",
+                                        code: Unset,
+                                    },
+                                ),
+                            },
+                        ],
+                        schema_url: "",
+                    },
+                ],
+                schema_url: "",
+            },
+        ],
+    }
+    "#);
+}
+
+/// Mutex to avoid concurrent mutation of env vars.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/tests/test_http_sink.rs
+++ b/tests/test_http_sink.rs
@@ -73,6 +73,18 @@ async fn test_http_protobuf_export() {
                     Resource {
                         attributes: [
                             KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
                                 key: "telemetry.sdk.language",
                                 value: Some(
                                     AnyValue {
@@ -103,18 +115,6 @@ async fn test_http_protobuf_export() {
                                         value: Some(
                                             StringValue(
                                                 "0.30.0",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "service.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "unknown_service",
                                             ),
                                         ),
                                     },
@@ -389,6 +389,18 @@ async fn test_http_json_export() {
                     Resource {
                         attributes: [
                             KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
                                 key: "telemetry.sdk.language",
                                 value: Some(
                                     AnyValue {
@@ -419,18 +431,6 @@ async fn test_http_json_export() {
                                         value: Some(
                                             StringValue(
                                                 "0.30.0",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "service.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "unknown_service",
                                             ),
                                         ),
                                     },


### PR DESCRIPTION
More testing always good!

Caught a bug with the `http/json` export where it was mistakenly still sending protobuf. That is now fixed.