### PR TITLE
cleanup `with_local_logfire` a little

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -100,19 +100,20 @@ mod tests {
         log::set_max_level(log::LevelFilter::Trace);
         let guard = set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            log::info!(logger: lf_logger, "root event");
-            log::info!(logger: lf_logger, target: "custom_target", "root event with target");
+        log::info!(logger: lf_logger, "root event");
+        log::info!(logger: lf_logger, target: "custom_target", "root event with target");
 
-            let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
-            log::info!(logger: lf_logger, "hello world log");
-            log::warn!(logger: lf_logger, "warning log");
-            log::error!(logger: lf_logger, "error log");
-            log::debug!(logger: lf_logger, "debug log");
-            log::trace!(logger: lf_logger, "trace log");
-        });
+        let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
+        log::info!(logger: lf_logger, "hello world log");
+        log::warn!(logger: lf_logger, "warning log");
+        log::error!(logger: lf_logger, "error log");
+        log::debug!(logger: lf_logger, "debug log");
+        log::trace!(logger: lf_logger, "trace log");
 
         let logs = log_exporter.get_emitted_logs().unwrap();
+
+        guard.shutdown().unwrap();
+
         let logs = make_deterministic_logs(logs, TEST_FILE, TEST_LINE);
         assert_debug_snapshot!(logs, @r#"
         [
@@ -178,7 +179,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        27,
+                                        26,
                                     ),
                                 ),
                             ),
@@ -311,7 +312,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        28,
+                                        27,
                                     ),
                                 ),
                             ),
@@ -444,7 +445,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        31,
+                                        30,
                                     ),
                                 ),
                             ),
@@ -577,7 +578,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        32,
+                                        31,
                                     ),
                                 ),
                             ),
@@ -710,7 +711,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        33,
+                                        32,
                                     ),
                                 ),
                             ),
@@ -843,7 +844,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        34,
+                                        33,
                                     ),
                                 ),
                             ),
@@ -976,7 +977,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        35,
+                                        34,
                                     ),
                                 ),
                             ),
@@ -1076,16 +1077,14 @@ mod tests {
         log::set_max_level(log::LevelFilter::Trace);
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            log::info!(logger: lf_logger, "root event");
-            log::info!(logger: lf_logger, target: "custom_target", "root event with target");
+        log::info!(logger: lf_logger, "root event");
+        log::info!(logger: lf_logger, target: "custom_target", "root event with target");
 
-            let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
-            log::info!(logger: lf_logger, "hello world log");
-            log::warn!(logger: lf_logger, "warning log");
-            log::error!(logger: lf_logger, "error log");
-            log::trace!(logger: lf_logger, "trace log");
-        });
+        let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
+        log::info!(logger: lf_logger, "hello world log");
+        log::warn!(logger: lf_logger, "warning log");
+        log::error!(logger: lf_logger, "error log");
+        log::trace!(logger: lf_logger, "trace log");
 
         guard.shutdown().unwrap();
 

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -441,7 +441,7 @@ mod tests {
 
         let guard = set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
+        {
             tracing::info!("root event");
             tracing::info!(name: "root event with value", field_value = 1);
 
@@ -452,8 +452,9 @@ mod tests {
 
             tracing::info!("hello world log");
             tracing::info!(name: "hello world log with value", field_value = 1);
-        });
+        }
 
+        guard.shutdown().unwrap();
         let spans = exporter.get_finished_spans().unwrap();
         assert_debug_snapshot!(spans, @r#"
         [
@@ -1982,7 +1983,7 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
+        {
             tracing::info!("root event");
             tracing::info!(name: "root event with value", field_value = 1);
 
@@ -1993,7 +1994,7 @@ mod tests {
 
             tracing::info!("hello world log");
             tracing::info!(name: "hello world log with value", field_value = 1);
-        });
+        }
 
         guard.shutdown().unwrap();
 

--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -418,14 +418,13 @@ mod tests {
         let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tracing::subscriber::with_default(guard.subscriber().clone(), || {
-                let root = crate::span!("root span").entered();
-                let _ = crate::span!("hello world span").entered();
-                let _ = crate::span!(level: Level::DEBUG, "debug span");
-                let _ = crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
-                crate::info!("hello world log");
-                panic!("oh no!");
-            });
+            let root = crate::span!("root span").entered();
+            let _ = crate::span!("hello world span").entered();
+            let _ = crate::span!(level: Level::DEBUG, "debug span");
+            let _ =
+                crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
+            crate::info!("hello world log");
+            panic!("oh no!");
         }))
         .unwrap_err();
 
@@ -466,14 +465,13 @@ mod tests {
         let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tracing::subscriber::with_default(guard.subscriber().clone(), || {
-                let root = crate::span!("root span").entered();
-                let _ = crate::span!("hello world span").entered();
-                let _ = crate::span!(level: Level::DEBUG, "debug span");
-                let _ = crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
-                crate::info!("hello world log");
-                panic!("oh no!");
-            });
+            let root = crate::span!("root span").entered();
+            let _ = crate::span!("hello world span").entered();
+            let _ = crate::span!(level: Level::DEBUG, "debug span");
+            let _ =
+                crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
+            crate::info!("hello world log");
+            panic!("oh no!");
         }))
         .unwrap_err();
 
@@ -513,14 +511,13 @@ mod tests {
         let guard = set_local_logfire(logfire);
 
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tracing::subscriber::with_default(guard.subscriber().clone(), || {
-                let root = crate::span!("root span").entered();
-                let _ = crate::span!("hello world span").entered();
-                let _ = crate::span!(level: Level::DEBUG, "debug span");
-                let _ = crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
-                crate::info!("hello world log");
-                panic!("oh no!");
-            });
+            let root = crate::span!("root span").entered();
+            let _ = crate::span!("hello world span").entered();
+            let _ = crate::span!(level: Level::DEBUG, "debug span");
+            let _ =
+                crate::span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
+            crate::info!("hello world log");
+            panic!("oh no!");
         }))
         .unwrap_err();
 

--- a/src/internal/exporters/remove_pending.rs
+++ b/src/internal/exporters/remove_pending.rs
@@ -106,15 +106,15 @@ mod tests {
 
         let guard = set_local_logfire(guard);
 
-        tracing::subscriber::with_default(guard.subscriber(), || {
+        {
             let _root = crate::span!("root span").entered();
             let _hello = crate::span!("hello world span").entered();
             let _debug = crate::span!(level: Level::DEBUG, "debug span").entered();
-        });
+        }
 
         guard.shutdown().unwrap();
-
         let mut spans = exporter.get_finished_spans().unwrap();
+
         spans.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         let spans = spans
             .iter()

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -465,12 +465,6 @@ pub struct LocalLogfireGuard {
 }
 
 impl LocalLogfireGuard {
-    /// Get the current tracer.
-    #[must_use]
-    pub fn subscriber(&self) -> Arc<dyn Subscriber + Send + Sync> {
-        self.logfire.subscriber.clone()
-    }
-
     /// Get the current meter provider
     #[must_use]
     pub fn meter_provider(&self) -> &SdkMeterProvider {

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -294,10 +294,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::error!("Test error message");
-            crate::error!("Test error with value", field = 42);
-        });
+        crate::error!("Test error message");
+        crate::error!("Test error with value", field = 42);
 
         guard.shutdown().unwrap();
 
@@ -328,10 +326,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::warn!("Test warn message");
-            crate::warn!("Test warn with value", field = "test");
-        });
+        crate::warn!("Test warn message");
+        crate::warn!("Test warn with value", field = "test");
 
         guard.shutdown().unwrap();
 
@@ -362,10 +358,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::info!("Test info message");
-            crate::info!("Test info with value", field = true);
-        });
+        crate::info!("Test info message");
+        crate::info!("Test info with value", field = true);
 
         guard.shutdown().unwrap();
 
@@ -396,10 +390,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::debug!("Test debug message");
-            crate::debug!("Test debug with value", field = 3.14);
-        });
+        crate::debug!("Test debug message");
+        crate::debug!("Test debug with value", field = 3.14);
 
         guard.shutdown().unwrap();
 
@@ -430,10 +422,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::trace!("Test trace message");
-            crate::trace!("Test trace with value", field = "debug_info");
-        });
+        crate::trace!("Test trace message");
+        crate::trace!("Test trace with value", field = "debug_info");
 
         guard.shutdown().unwrap();
 
@@ -464,10 +454,8 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire);
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            crate::log!(Level::INFO, "Test log message");
-            crate::log!(Level::INFO, "Test log with value", field = "explicit");
-        });
+        crate::log!(Level::INFO, "Test log message");
+        crate::log!(Level::INFO, "Test log with value", field = "explicit");
 
         guard.shutdown().unwrap();
 
@@ -498,11 +486,9 @@ mod tests {
 
         let guard = crate::set_local_logfire(logfire.clone());
 
-        tracing::subscriber::with_default(guard.subscriber().clone(), || {
-            let parent_span = crate::span!("parent span");
-            crate::info!(parent: &parent_span, "Test info with parent");
-            crate::error!(parent: &parent_span, "Test error with parent", field = "parent_test");
-        });
+        let parent_span = crate::span!("parent span");
+        crate::info!(parent: &parent_span, "Test info with parent");
+        crate::error!(parent: &parent_span, "Test error with parent", field = "parent_test");
 
         guard.shutdown().unwrap();
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -256,6 +256,7 @@ pub struct DeterministicResourceMetrics {
 }
 
 /// Find a span by name in a slice of SpanData.
+#[track_caller]
 pub fn find_span<'a>(
     spans: &'a [opentelemetry_sdk::trace::SpanData],
     name: &str,

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -65,16 +65,16 @@ fn test_basic_span() {
     let value = 42;
 
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        tracing::subscriber::with_default(guard.subscriber(), || {
-            let root = span!("root span").entered();
-            let _ = span!("hello world span", attr = "x", dotted.attr = "y").entered();
-            let _ = span!(level: Level::DEBUG, "debug span");
-            let _ = span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
-            info!("hello world log {value}", attr = "x", dotted.attr = "y");
-            panic!("oh no!");
-        });
+        let root = span!("root span").entered();
+        let _ = span!("hello world span", attr = "x", dotted.attr = "y").entered();
+        let _ = span!(level: Level::DEBUG, "debug span");
+        let _ = span!(parent: &root, level: Level::DEBUG, "debug span with explicit parent");
+        info!("hello world log {value}", attr = "x", dotted.attr = "y");
+        panic!("oh no!");
     }))
     .unwrap_err();
+
+    guard.shutdown().unwrap();
 
     let spans = exporter.get_finished_spans().unwrap();
     assert_debug_snapshot!(spans, @r#"
@@ -128,7 +128,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -254,7 +254,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -410,7 +410,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -572,7 +572,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        36,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -708,7 +708,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        36,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -850,7 +850,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        37,
+                        36,
                     ),
                 },
                 KeyValue {
@@ -986,7 +986,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        37,
+                        36,
                     ),
                 },
                 KeyValue {
@@ -1128,7 +1128,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -1302,7 +1302,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    38,
+                                    37,
                                 ),
                             ),
                         ),
@@ -1457,7 +1457,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    39,
+                                    38,
                                 ),
                             ),
                         ),

--- a/tests/test_log_attributes.rs
+++ b/tests/test_log_attributes.rs
@@ -23,20 +23,20 @@ fn test_log_macro_attributes() {
         .unwrap();
     let guard = logfire::set_local_logfire(logfire);
 
-    tracing::subscriber::with_default(guard.subscriber(), || {
-        let _ = log!(Level::INFO, "string_attr_log", foo = "bar");
-        let _ = log!(Level::INFO, "int_attr_log", num = 42);
-        let _ = log!(Level::INFO, "bool_attr_log", flag = true);
-        let _ = log!(Level::INFO, "dotted_attr_log", dotted.key = "value");
-        let _ = log!(
-            Level::INFO,
-            "multi_attr_log",
-            a = 1,
-            b = "two",
-            c = false,
-            d.e = 3
-        );
-    });
+    let _ = log!(Level::INFO, "string_attr_log", foo = "bar");
+    let _ = log!(Level::INFO, "int_attr_log", num = 42);
+    let _ = log!(Level::INFO, "bool_attr_log", flag = true);
+    let _ = log!(Level::INFO, "dotted_attr_log", dotted.key = "value");
+    let _ = log!(
+        Level::INFO,
+        "multi_attr_log",
+        a = 1,
+        b = "two",
+        c = false,
+        d.e = 3
+    );
+
+    guard.shutdown().unwrap();
     let logs = log_exporter.get_emitted_logs().unwrap();
 
     // String attribute
@@ -107,19 +107,19 @@ fn test_log_macro_shorthand_ident() {
         .unwrap();
 
     let guard = logfire::set_local_logfire(logfire);
-    tracing::subscriber::with_default(guard.subscriber(), || {
-        let _ = log!(Level::INFO, "dotted_attr_log", dotted.key);
-        let _ = log!(Level::INFO, "int_attr_log", int_val);
-        let _ = log!(Level::INFO, "bool_attr_log", bool_val);
-        let _ = log!(
-            Level::INFO,
-            "multi_attr_log",
-            multi.a,
-            multi.b,
-            multi.c,
-            multi.d_e
-        );
-    });
+    let _ = log!(Level::INFO, "dotted_attr_log", dotted.key);
+    let _ = log!(Level::INFO, "int_attr_log", int_val);
+    let _ = log!(Level::INFO, "bool_attr_log", bool_val);
+    let _ = log!(
+        Level::INFO,
+        "multi_attr_log",
+        multi.a,
+        multi.b,
+        multi.c,
+        multi.d_e
+    );
+
+    guard.shutdown().unwrap();
 
     let logs = log_exporter.get_emitted_logs().unwrap();
 

--- a/tests/test_span_attributes.rs
+++ b/tests/test_span_attributes.rs
@@ -21,14 +21,14 @@ fn test_span_macro_attributes() {
         .unwrap();
     let guard = logfire::set_local_logfire(logfire);
 
-    tracing::subscriber::with_default(guard.subscriber(), || {
-        let _ = span!("string_attr_span", foo = "bar");
-        let _ = span!("int_attr_span", num = 42);
-        let _ = span!("bool_attr_span", flag = true);
-        let _ = span!("dotted_attr_span", dotted.key = "value");
-        let _ = span!("multi_attr_span", a = 1, b = "two", c = false, d.e = 3);
-    });
+    let _ = span!("string_attr_span", foo = "bar");
+    let _ = span!("int_attr_span", num = 42);
+    let _ = span!("bool_attr_span", flag = true);
+    let _ = span!("dotted_attr_span", dotted.key = "value");
+    let _ = span!("multi_attr_span", a = 1, b = "two", c = false, d.e = 3);
+
     let spans = exporter.get_finished_spans().unwrap();
+    guard.shutdown().unwrap();
 
     // String attribute
     let span = find_span(&spans, "string_attr_span");
@@ -95,15 +95,16 @@ fn test_span_macro_shorthand_ident() {
         ))
         .finish()
         .unwrap();
+
     let guard = logfire::set_local_logfire(logfire);
-    tracing::subscriber::with_default(guard.subscriber(), || {
-        let _ = span!("dotted_attr_span", dotted.key);
-        let _ = span!("int_attr_span", int_val);
-        let _ = span!("bool_attr_span", bool_val);
-        let _ = span!("multi_attr_span", multi.a, multi.b, multi.c, multi.d_e);
-    });
+
+    let _ = span!("dotted_attr_span", dotted.key);
+    let _ = span!("int_attr_span", int_val);
+    let _ = span!("bool_attr_span", bool_val);
+    let _ = span!("multi_attr_span", multi.a, multi.b, multi.c, multi.d_e);
 
     let spans = exporter.get_finished_spans().unwrap();
+    guard.shutdown().unwrap();
 
     // Dotted key attribute
     let span = find_span(&spans, "dotted_attr_span");


### PR DESCRIPTION
Simplifies stuff a bit by relying on the fact that `set_local_logfire` also sets a tracing guard.

As this is for now just in tests, will merge assuming green CI.