### PR TITLE
suppress telemetry from otel export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,29 @@ tonic = { version = "0.13", optional = true }
 
 rand = "0.9.0"
 
-opentelemetry = { version = "0.30", default-features = false, features = ["trace", "logs"] }
-opentelemetry_sdk = { version = "0.30", default-features = false, features = ["trace", "experimental_metrics_custom_reader", "logs"] }
-opentelemetry-otlp = { version = "0.30", default-features = false, features = ["trace", "metrics", "logs"] }
+opentelemetry = { version = "0.30", default-features = false, features = [
+    "trace",
+    "logs",
+] }
+opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+    "trace",
+    "experimental_metrics_custom_reader",
+    "experimental_trace_batch_span_processor_with_async_runtime",
+    "experimental_logs_batch_log_processor_with_async_runtime",
+    "experimental_metrics_periodicreader_with_async_runtime",
+    "rt-tokio",
+    "logs",
+] }
+opentelemetry-otlp = { version = "0.30", default-features = false, features = [
+    "trace",
+    "metrics",
+    "logs",
+] }
 futures-util = "0.3"
 
+tokio = { version = "1.44.1", default-features = false, features = [
+    "rt-multi-thread",
+] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.31"
@@ -40,23 +58,36 @@ regex = "1.11.1"
 async-trait = "0.1.88"
 futures = { version = "0.3.31", features = ["futures-executor"] }
 insta = "1.42.1"
-opentelemetry_sdk = { version = "0.30", default-features = false, features = ["testing"] }
+opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+    "testing",
+] }
 regex = "1.11.1"
-tokio = {version = "1.44.1", features = ["test-util", "macros", "rt-multi-thread"] }
+tokio = { version = "1.44.1", features = [
+    "test-util",
+    "macros",
+    "rt-multi-thread",
+] }
 ulid = "1.2.0"
 wiremock = "0.6"
 tonic-build = "0.13"
 tonic = { version = "0.13", features = ["transport"] }
 prost = "0.13"
-opentelemetry-proto = { version = "0.30", features = ["tonic", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.30", features = [
+    "tonic",
+    "gen-tonic-messages",
+] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
 # Dependencies for examples
 axum = { version = "0.8", features = ["macros"] }
-axum-tracing-opentelemetry = { version = "0.29", features = ["tracing_level_info"] }
+axum-tracing-opentelemetry = { version = "0.29", features = [
+    "tracing_level_info",
+] }
 axum-otel-metrics = "0.12.0"
 actix-web = "4.0"
-opentelemetry-instrumentation-actix-web = { version = "0.22", features = ["metrics"] }
+opentelemetry-instrumentation-actix-web = { version = "0.22", features = [
+    "metrics",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures-util = "0.3"
@@ -65,9 +96,22 @@ tempfile = "3.20.0"
 [features]
 default = ["data-dir", "export-http-protobuf"]
 data-dir = ["dep:serde", "dep:serde_json"]
-export-grpc = ["opentelemetry-otlp/grpc-tonic", "opentelemetry-otlp/tls", "dep:http", "dep:tonic"]
-export-http-protobuf = ["opentelemetry-otlp/http-proto", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
-export-http-json = ["opentelemetry-otlp/http-json", "opentelemetry-otlp/reqwest-blocking-client", "opentelemetry-otlp/reqwest-rustls"]
+export-grpc = [
+    "opentelemetry-otlp/grpc-tonic",
+    "opentelemetry-otlp/tls",
+    "dep:http",
+    "dep:tonic",
+]
+export-http-protobuf = [
+    "opentelemetry-otlp/http-proto",
+    "opentelemetry-otlp/reqwest-client",
+    "opentelemetry-otlp/reqwest-rustls",
+]
+export-http-json = [
+    "opentelemetry-otlp/http-json",
+    "opentelemetry-otlp/reqwest-client",
+    "opentelemetry-otlp/reqwest-rustls",
+]
 
 [lints.rust]
 missing_docs = "warn"

--- a/src/internal/log_processor_shutdown_hack.rs
+++ b/src/internal/log_processor_shutdown_hack.rs
@@ -1,0 +1,44 @@
+use opentelemetry_sdk::logs::LogProcessor;
+
+/// Workaround for https://github.com/open-telemetry/opentelemetry-rust/issues/3132
+///
+/// This wraps the inner exporter and redirects calls to `shutdown_with_timeout` to
+/// `shutdown`.
+#[derive(Debug)]
+pub(crate) struct LogProcessorShutdownHack<T>(T);
+
+impl<T> LogProcessorShutdownHack<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T: LogProcessor> LogProcessor for LogProcessorShutdownHack<T> {
+    fn emit(
+        &self,
+        data: &mut opentelemetry_sdk::logs::SdkLogRecord,
+        instrumentation: &opentelemetry::InstrumentationScope,
+    ) {
+        self.0.emit(data, instrumentation);
+    }
+
+    fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.0.force_flush()
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        _timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        // Calling `.shutdown` here is the deliberate purpose of the abstraction
+        self.0.shutdown()
+    }
+
+    fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.0.shutdown()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.0.set_resource(resource);
+    }
+}

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod constants;
 pub(crate) mod env;
 pub(crate) mod exporters;
+pub(crate) mod log_processor_shutdown_hack;
 pub(crate) mod logfire_tracer;
 pub(crate) mod span_data_ext;

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -190,9 +190,6 @@ async fn test_grpc_protobuf_export() {
         info!("Test log message from within span");
     });
 
-    // need to allow some time for logs to flush
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
     tokio::task::spawn_blocking(move || logfire.shutdown())
         .await
         .unwrap()

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -2,7 +2,11 @@
 #![cfg(feature = "export-grpc")]
 
 use insta::assert_debug_snapshot;
-use logfire::{configure, set_local_logfire, span};
+use logfire::{configure, info, set_local_logfire, span};
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+    logs_service_server::{LogsService, LogsServiceServer},
+};
 use opentelemetry_proto::tonic::collector::trace::v1::{
     ExportTraceServiceRequest, ExportTraceServiceResponse,
     trace_service_server::{TraceService, TraceServiceServer},
@@ -28,6 +32,18 @@ impl MockTraceService {
     }
 }
 
+/// Mock logs service that captures requests for testing
+#[derive(Clone)]
+struct MockLogsService {
+    captured: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+}
+
+impl MockLogsService {
+    fn new(captured: Arc<Mutex<Vec<ExportLogsServiceRequest>>>) -> Self {
+        Self { captured }
+    }
+}
+
 #[tonic::async_trait]
 impl TraceService for MockTraceService {
     async fn export(
@@ -48,20 +64,49 @@ impl TraceService for MockTraceService {
     }
 }
 
+#[tonic::async_trait]
+impl LogsService for MockLogsService {
+    async fn export(
+        &self,
+        request: Request<ExportLogsServiceRequest>,
+    ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        let logs_request = request.into_inner();
+
+        // Capture the request for testing
+        {
+            let mut captured = self.captured.lock().unwrap();
+            captured.push(logs_request);
+        }
+
+        Ok(Response::new(ExportLogsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
 /// Start a mock gRPC server and return its address
-async fn start_mock_grpc_server() -> (String, Arc<Mutex<Vec<ExportTraceServiceRequest>>>) {
+async fn start_mock_grpc_server() -> (
+    String,
+    Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+    Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let addr_str = format!("http://{}", addr);
 
-    let captured = Arc::new(Mutex::new(Vec::new()));
-    let captured_clone = captured.clone();
+    let captured_traces = Arc::new(Mutex::new(Vec::new()));
+    let captured_traces_clone = captured_traces.clone();
 
-    let trace_service = MockTraceService::new(captured_clone);
+    let captured_logs = Arc::new(Mutex::new(Vec::new()));
+    let captured_logs_clone = captured_logs.clone();
+
+    let trace_service = MockTraceService::new(captured_traces_clone);
+    let logs_service = MockLogsService::new(captured_logs_clone);
 
     tokio::spawn(async move {
         Server::builder()
             .add_service(TraceServiceServer::new(trace_service))
+            .add_service(LogsServiceServer::new(logs_service))
             .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
             .await
             .expect("gRPC server failed to start");
@@ -75,7 +120,7 @@ async fn start_mock_grpc_server() -> (String, Arc<Mutex<Vec<ExportTraceServiceRe
 
     tonic::client::Grpc::new(channel).ready().await.unwrap();
 
-    (addr_str, captured)
+    (addr_str, captured_traces, captured_logs)
 }
 
 /// Test gRPC protobuf export infrastructure
@@ -83,7 +128,7 @@ async fn start_mock_grpc_server() -> (String, Arc<Mutex<Vec<ExportTraceServiceRe
 async fn test_grpc_protobuf_export() {
     use logfire::config::AdvancedOptions;
 
-    let (server_addr, captured) = start_mock_grpc_server().await;
+    let (server_addr, captured_traces, captured_logs) = start_mock_grpc_server().await;
 
     let env_guard = ENV_MUTEX.lock().unwrap();
     // SAFETY: Holding mutex to prevent other threads interacting with env
@@ -110,20 +155,25 @@ async fn test_grpc_protobuf_export() {
     drop(env_guard);
 
     let guard = set_local_logfire(logfire);
-    span!("grpc_test_span").in_scope(|| {});
+    span!("grpc_test_span").in_scope(|| {
+        info!("Test log message from within span");
+    });
+    info!("Test log message outside span");
     tokio::task::spawn_blocking(move || guard.shutdown())
         .await
         .unwrap()
         .unwrap();
 
-    let requests = captured.lock().unwrap();
+    let trace_requests = captured_traces.lock().unwrap();
+    let log_requests = captured_logs.lock().unwrap();
 
-    assert_eq!(requests.len(), 1);
+    assert_eq!(trace_requests.len(), 1);
+    assert!(!log_requests.is_empty()); // At least one log request
 
-    let mut body = requests[0].clone();
-    make_trace_request_deterministic(&mut body);
+    let mut trace_body = trace_requests[0].clone();
+    make_trace_request_deterministic(&mut trace_body);
 
-    assert_debug_snapshot!(body, @r#"
+    assert_debug_snapshot!(trace_body, @r#"
     ExportTraceServiceRequest {
         resource_spans: [
             ResourceSpans {
@@ -211,6 +261,316 @@ async fn test_grpc_protobuf_export() {
                                     0,
                                     0,
                                     0,
+                                    241,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    243,
+                                ],
+                                trace_state: "",
+                                parent_span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    242,
+                                ],
+                                flags: 1,
+                                name: "poll",
+                                kind: Internal,
+                                start_time_unix_nano: 0,
+                                end_time_unix_nano: 0,
+                                attributes: [
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        269,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "h2::proto::connection",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.level_num",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        1,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.span_type",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "pending_span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                events: [],
+                                dropped_events_count: 0,
+                                links: [],
+                                dropped_links_count: 0,
+                                status: Some(
+                                    Status {
+                                        message: "",
+                                        code: Unset,
+                                    },
+                                ),
+                            },
+                            Span {
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    241,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    244,
+                                ],
+                                trace_state: "",
+                                parent_span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    242,
+                                ],
+                                flags: 1,
+                                name: "poll_ready",
+                                kind: Internal,
+                                start_time_unix_nano: 1000000000,
+                                end_time_unix_nano: 2000000000,
+                                attributes: [
+                                    KeyValue {
+                                        key: "busy_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        188,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "h2::proto::connection",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "idle_ns",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.level_num",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        1,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.span_type",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "span",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        0,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                events: [],
+                                dropped_events_count: 0,
+                                links: [],
+                                dropped_links_count: 0,
+                                status: Some(
+                                    Status {
+                                        message: "",
+                                        code: Unset,
+                                    },
+                                ),
+                            },
+                            Span {
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
                                     240,
                                 ],
                                 span_id: [
@@ -228,8 +588,8 @@ async fn test_grpc_protobuf_export() {
                                 flags: 1,
                                 name: "grpc_test_span",
                                 kind: Internal,
-                                start_time_unix_nano: 0,
-                                end_time_unix_nano: 1000000000,
+                                start_time_unix_nano: 3000000000,
+                                end_time_unix_nano: 4000000000,
                                 attributes: [
                                     KeyValue {
                                         key: "busy_ns",
@@ -261,7 +621,7 @@ async fn test_grpc_protobuf_export() {
                                             AnyValue {
                                                 value: Some(
                                                     IntValue(
-                                                        113,
+                                                        158,
                                                     ),
                                                 ),
                                             },
@@ -375,6 +735,585 @@ async fn test_grpc_protobuf_export() {
                                         code: Unset,
                                     },
                                 ),
+                            },
+                        ],
+                        schema_url: "",
+                    },
+                ],
+                schema_url: "",
+            },
+        ],
+    }
+    "#);
+
+    assert_eq!(log_requests.len(), 1);
+
+    let mut log_body = log_requests[0].clone();
+
+    // TODO deterministic
+
+    assert_debug_snapshot!(log_body, @r#"
+    ExportLogsServiceRequest {
+        resource_logs: [
+            ResourceLogs {
+                resource: Some(
+                    Resource {
+                        attributes: [
+                            KeyValue {
+                                key: "service.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "unknown_service",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.language",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "rust",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.name",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "opentelemetry",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                            KeyValue {
+                                key: "telemetry.sdk.version",
+                                value: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "0.30.0",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                            },
+                        ],
+                        dropped_attributes_count: 0,
+                        entity_refs: [],
+                    },
+                ),
+                scope_logs: [
+                    ScopeLogs {
+                        scope: Some(
+                            InstrumentationScope {
+                                name: "logfire",
+                                version: "",
+                                attributes: [],
+                                dropped_attributes_count: 0,
+                            },
+                        ),
+                        log_records: [
+                            LogRecord {
+                                time_unix_nano: 1755687117943699156,
+                                observed_time_unix_nano: 1755687117943699156,
+                                severity_number: Info,
+                                severity_text: "INFO",
+                                body: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "Test log message from within span",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                attributes: [
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{\"type\":\"object\",\"properties\":{}}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        2,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tests/test_grpc_sink.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        159,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_sink",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                flags: 1,
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    240,
+                                ],
+                                event_name: "Test log message from within span",
+                            },
+                            LogRecord {
+                                time_unix_nano: 1755687117943732313,
+                                observed_time_unix_nano: 1755687117943732313,
+                                severity_number: Info,
+                                severity_text: "INFO",
+                                body: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "Test log message outside span",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                attributes: [
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{\"type\":\"object\",\"properties\":{}}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        2,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tests/test_grpc_sink.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        161,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_sink",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                flags: 0,
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                ],
+                                event_name: "Test log message outside span",
+                            },
+                            LogRecord {
+                                time_unix_nano: 1755687117943868666,
+                                observed_time_unix_nano: 1755687117943868666,
+                                severity_number: Trace,
+                                severity_text: "TRACE",
+                                body: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "connection accepted",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                attributes: [
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        2,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tonic-0.13.1/src/transport/server/mod.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        726,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "tonic::transport::server",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                flags: 0,
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                ],
+                                event_name: "",
+                            },
+                            LogRecord {
+                                time_unix_nano: 1755687117943961578,
+                                observed_time_unix_nano: 1755687117943961578,
+                                severity_number: Trace,
+                                severity_text: "TRACE",
+                                body: Some(
+                                    AnyValue {
+                                        value: Some(
+                                            StringValue(
+                                                "event /home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs:273",
+                                            ),
+                                        ),
+                                    },
+                                ),
+                                attributes: [
+                                    KeyValue {
+                                        key: "connection.state",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "Open",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "logfire.json_schema",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "{}",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.id",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        2,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "thread.name",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "test_grpc_protobuf_export",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.filepath",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.lineno",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    IntValue(
+                                                        273,
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                    KeyValue {
+                                        key: "code.namespace",
+                                        value: Some(
+                                            AnyValue {
+                                                value: Some(
+                                                    StringValue(
+                                                        "h2::proto::connection",
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ],
+                                dropped_attributes_count: 0,
+                                flags: 1,
+                                trace_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    241,
+                                ],
+                                span_id: [
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    242,
+                                ],
+                                event_name: "",
                             },
                         ],
                         schema_url: "",

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -1,8 +1,10 @@
 //! Integration tests for gRPC sink with mock server.
-#![cfg(feature = "export-grpc")]
+// #![cfg(feature = "export-grpc")]
 
+use futures::channel::oneshot;
 use insta::assert_debug_snapshot;
-use logfire::{configure, info, set_local_logfire, span};
+use logfire::{configure, info, span};
+use opentelemetry::Context;
 use opentelemetry_proto::tonic::collector::logs::v1::{
     ExportLogsServiceRequest, ExportLogsServiceResponse,
     logs_service_server::{LogsService, LogsServiceServer},
@@ -15,7 +17,9 @@ use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tonic::{Request, Response, Status, transport::Server};
 
-use crate::test_utils::{DeterministicIdGenerator, make_trace_request_deterministic};
+use crate::test_utils::{
+    DeterministicIdGenerator, make_log_request_deterministic, make_trace_request_deterministic,
+};
 
 #[path = "../src/test_utils.rs"]
 mod test_utils;
@@ -86,41 +90,67 @@ impl LogsService for MockLogsService {
 
 /// Start a mock gRPC server and return its address
 async fn start_mock_grpc_server() -> (
+    oneshot::Sender<()>,
     String,
     Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
     Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
 ) {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    let addr_str = format!("http://{}", addr);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
-    let captured_traces = Arc::new(Mutex::new(Vec::new()));
-    let captured_traces_clone = captured_traces.clone();
+    // run the server in a separate thread with context suppression
+    std::thread::spawn(move || {
+        let _guard = Context::enter_telemetry_suppressed_scope();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-    let captured_logs = Arc::new(Mutex::new(Vec::new()));
-    let captured_logs_clone = captured_logs.clone();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime");
 
-    let trace_service = MockTraceService::new(captured_traces_clone);
-    let logs_service = MockLogsService::new(captured_logs_clone);
+        rt.block_on(async move {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let addr_str = format!("http://{}", addr);
 
-    tokio::spawn(async move {
-        Server::builder()
-            .add_service(TraceServiceServer::new(trace_service))
-            .add_service(LogsServiceServer::new(logs_service))
-            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
-            .await
-            .expect("gRPC server failed to start");
+            let captured_traces = Arc::new(Mutex::new(Vec::new()));
+            let captured_traces_clone = captured_traces.clone();
+
+            let captured_logs = Arc::new(Mutex::new(Vec::new()));
+            let captured_logs_clone = captured_logs.clone();
+
+            let trace_service = MockTraceService::new(captured_traces_clone);
+            let logs_service = MockLogsService::new(captured_logs_clone);
+
+            tokio::spawn(async move {
+                Server::builder()
+                    .add_service(TraceServiceServer::new(trace_service))
+                    .add_service(LogsServiceServer::new(logs_service))
+                    .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                    .await
+                    .expect("gRPC server failed to start");
+            });
+
+            let channel = tonic::transport::Channel::from_shared(addr_str.clone())
+                .unwrap()
+                .connect()
+                .await
+                .expect("Failed to connect to mock gRPC server");
+
+            tonic::client::Grpc::new(channel).ready().await.unwrap();
+
+            ready_tx
+                .send((shutdown_tx, addr_str, captured_traces, captured_logs))
+                .unwrap();
+
+            tokio::select! {
+                _ = shutdown_rx => {
+                    // Shutdown signal received
+                }
+            }
+        });
     });
 
-    let channel = tonic::transport::Channel::from_shared(addr_str.clone())
-        .unwrap()
-        .connect()
-        .await
-        .expect("Failed to connect to mock gRPC server");
-
-    tonic::client::Grpc::new(channel).ready().await.unwrap();
-
-    (addr_str, captured_traces, captured_logs)
+    ready_rx.await.unwrap()
 }
 
 /// Test gRPC protobuf export infrastructure
@@ -128,7 +158,7 @@ async fn start_mock_grpc_server() -> (
 async fn test_grpc_protobuf_export() {
     use logfire::config::AdvancedOptions;
 
-    let (server_addr, captured_traces, captured_logs) = start_mock_grpc_server().await;
+    let (shutdown_tx, server_addr, captured_traces, captured_logs) = start_mock_grpc_server().await;
 
     let env_guard = ENV_MUTEX.lock().unwrap();
     // SAFETY: Holding mutex to prevent other threads interacting with env
@@ -136,8 +166,9 @@ async fn test_grpc_protobuf_export() {
         std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
     }
 
+    // NB deliberately not using local logfire here; this way we're validating
+    // that any tonic telemetry from the exporter is not captured
     let logfire = configure()
-        .local()
         .send_to_logfire(true)
         .with_token("test-token")
         .with_advanced_options(
@@ -154,1175 +185,618 @@ async fn test_grpc_protobuf_export() {
     }
     drop(env_guard);
 
-    let guard = set_local_logfire(logfire);
+    info!("Test log message outside span");
     span!("grpc_test_span").in_scope(|| {
         info!("Test log message from within span");
     });
-    info!("Test log message outside span");
-    tokio::task::spawn_blocking(move || guard.shutdown())
+
+    // need to allow some time for logs to flush
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    tokio::task::spawn_blocking(move || logfire.shutdown())
         .await
         .unwrap()
         .unwrap();
 
-    let trace_requests = captured_traces.lock().unwrap();
-    let log_requests = captured_logs.lock().unwrap();
+    shutdown_tx.send(()).unwrap();
 
-    assert_eq!(trace_requests.len(), 1);
-    assert!(!log_requests.is_empty()); // At least one log request
+    let mut trace_requests = std::mem::take(&mut *captured_traces.lock().unwrap());
+    let mut log_requests = std::mem::take(&mut *captured_logs.lock().unwrap());
 
-    let mut trace_body = trace_requests[0].clone();
-    make_trace_request_deterministic(&mut trace_body);
-
-    assert_debug_snapshot!(trace_body, @r#"
-    ExportTraceServiceRequest {
-        resource_spans: [
-            ResourceSpans {
-                resource: Some(
-                    Resource {
-                        attributes: [
-                            KeyValue {
-                                key: "service.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "unknown_service",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.language",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "rust",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "opentelemetry",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.version",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "0.30.0",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                        ],
-                        dropped_attributes_count: 0,
-                        entity_refs: [],
-                    },
-                ),
-                scope_spans: [
-                    ScopeSpans {
-                        scope: Some(
-                            InstrumentationScope {
-                                name: "logfire",
-                                version: "",
-                                attributes: [],
-                                dropped_attributes_count: 0,
-                            },
-                        ),
-                        spans: [
-                            Span {
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    241,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    243,
-                                ],
-                                trace_state: "",
-                                parent_span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    242,
-                                ],
-                                flags: 1,
-                                name: "poll",
-                                kind: Internal,
-                                start_time_unix_nano: 0,
-                                end_time_unix_nano: 0,
-                                attributes: [
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        269,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "h2::proto::connection",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.level_num",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        1,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.span_type",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "pending_span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                events: [],
-                                dropped_events_count: 0,
-                                links: [],
-                                dropped_links_count: 0,
-                                status: Some(
-                                    Status {
-                                        message: "",
-                                        code: Unset,
-                                    },
-                                ),
-                            },
-                            Span {
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    241,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    244,
-                                ],
-                                trace_state: "",
-                                parent_span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    242,
-                                ],
-                                flags: 1,
-                                name: "poll_ready",
-                                kind: Internal,
-                                start_time_unix_nano: 1000000000,
-                                end_time_unix_nano: 2000000000,
-                                attributes: [
-                                    KeyValue {
-                                        key: "busy_ns",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        188,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "h2::proto::connection",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "idle_ns",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.level_num",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        1,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.span_type",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                events: [],
-                                dropped_events_count: 0,
-                                links: [],
-                                dropped_links_count: 0,
-                                status: Some(
-                                    Status {
-                                        message: "",
-                                        code: Unset,
-                                    },
-                                ),
-                            },
-                            Span {
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    240,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    240,
-                                ],
-                                trace_state: "",
-                                parent_span_id: [],
-                                flags: 1,
-                                name: "grpc_test_span",
-                                kind: Internal,
-                                start_time_unix_nano: 3000000000,
-                                end_time_unix_nano: 4000000000,
-                                attributes: [
-                                    KeyValue {
-                                        key: "busy_ns",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "tests/test_grpc_sink.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        158,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_sink",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "idle_ns",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.json_schema",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "{\"type\":\"object\",\"properties\":{}}",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.level_num",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        9,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.msg",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "grpc_test_span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.span_type",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        0,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                events: [],
-                                dropped_events_count: 0,
-                                links: [],
-                                dropped_links_count: 0,
-                                status: Some(
-                                    Status {
-                                        message: "",
-                                        code: Unset,
-                                    },
-                                ),
-                            },
-                        ],
-                        schema_url: "",
-                    },
-                ],
-                schema_url: "",
-            },
-        ],
+    for req in &mut trace_requests {
+        make_trace_request_deterministic(req);
     }
+
+    assert_debug_snapshot!(trace_requests, @r#"
+    [
+        ExportTraceServiceRequest {
+            resource_spans: [
+                ResourceSpans {
+                    resource: Some(
+                        Resource {
+                            attributes: [
+                                KeyValue {
+                                    key: "service.name",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "unknown_service",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.language",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "rust",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.name",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "opentelemetry",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.version",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "0.30.0",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                            dropped_attributes_count: 0,
+                            entity_refs: [],
+                        },
+                    ),
+                    scope_spans: [
+                        ScopeSpans {
+                            scope: Some(
+                                InstrumentationScope {
+                                    name: "logfire",
+                                    version: "",
+                                    attributes: [],
+                                    dropped_attributes_count: 0,
+                                },
+                            ),
+                            spans: [
+                                Span {
+                                    trace_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        240,
+                                    ],
+                                    span_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        240,
+                                    ],
+                                    trace_state: "",
+                                    parent_span_id: [],
+                                    flags: 1,
+                                    name: "grpc_test_span",
+                                    kind: Internal,
+                                    start_time_unix_nano: 0,
+                                    end_time_unix_nano: 1000000000,
+                                    attributes: [
+                                        KeyValue {
+                                            key: "busy_ns",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            0,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.filepath",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "tests/test_grpc_sink.rs",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.lineno",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            189,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.namespace",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_sink",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "idle_ns",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            0,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.json_schema",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "{\"type\":\"object\",\"properties\":{}}",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.level_num",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            9,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.msg",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "grpc_test_span",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.span_type",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "span",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.id",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            0,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.name",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_protobuf_export",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    dropped_attributes_count: 0,
+                                    events: [],
+                                    dropped_events_count: 0,
+                                    links: [],
+                                    dropped_links_count: 0,
+                                    status: Some(
+                                        Status {
+                                            message: "",
+                                            code: Unset,
+                                        },
+                                    ),
+                                },
+                            ],
+                            schema_url: "",
+                        },
+                    ],
+                    schema_url: "",
+                },
+            ],
+        },
+    ]
     "#);
 
-    assert_eq!(log_requests.len(), 1);
-
-    let mut log_body = log_requests[0].clone();
-
-    // TODO deterministic
-
-    assert_debug_snapshot!(log_body, @r#"
-    ExportLogsServiceRequest {
-        resource_logs: [
-            ResourceLogs {
-                resource: Some(
-                    Resource {
-                        attributes: [
-                            KeyValue {
-                                key: "service.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "unknown_service",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.language",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "rust",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.name",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "opentelemetry",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                            KeyValue {
-                                key: "telemetry.sdk.version",
-                                value: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "0.30.0",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                            },
-                        ],
-                        dropped_attributes_count: 0,
-                        entity_refs: [],
-                    },
-                ),
-                scope_logs: [
-                    ScopeLogs {
-                        scope: Some(
-                            InstrumentationScope {
-                                name: "logfire",
-                                version: "",
-                                attributes: [],
-                                dropped_attributes_count: 0,
-                            },
-                        ),
-                        log_records: [
-                            LogRecord {
-                                time_unix_nano: 1755687117943699156,
-                                observed_time_unix_nano: 1755687117943699156,
-                                severity_number: Info,
-                                severity_text: "INFO",
-                                body: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "Test log message from within span",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                attributes: [
-                                    KeyValue {
-                                        key: "logfire.json_schema",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "{\"type\":\"object\",\"properties\":{}}",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        2,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "tests/test_grpc_sink.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        159,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_sink",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                flags: 1,
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    240,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    240,
-                                ],
-                                event_name: "Test log message from within span",
-                            },
-                            LogRecord {
-                                time_unix_nano: 1755687117943732313,
-                                observed_time_unix_nano: 1755687117943732313,
-                                severity_number: Info,
-                                severity_text: "INFO",
-                                body: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "Test log message outside span",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                attributes: [
-                                    KeyValue {
-                                        key: "logfire.json_schema",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "{\"type\":\"object\",\"properties\":{}}",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        2,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "tests/test_grpc_sink.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        161,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_sink",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                flags: 0,
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                ],
-                                event_name: "Test log message outside span",
-                            },
-                            LogRecord {
-                                time_unix_nano: 1755687117943868666,
-                                observed_time_unix_nano: 1755687117943868666,
-                                severity_number: Trace,
-                                severity_text: "TRACE",
-                                body: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "connection accepted",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                attributes: [
-                                    KeyValue {
-                                        key: "logfire.json_schema",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "{}",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        2,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tonic-0.13.1/src/transport/server/mod.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        726,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "tonic::transport::server",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                flags: 0,
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                ],
-                                event_name: "",
-                            },
-                            LogRecord {
-                                time_unix_nano: 1755687117943961578,
-                                observed_time_unix_nano: 1755687117943961578,
-                                severity_number: Trace,
-                                severity_text: "TRACE",
-                                body: Some(
-                                    AnyValue {
-                                        value: Some(
-                                            StringValue(
-                                                "event /home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs:273",
-                                            ),
-                                        ),
-                                    },
-                                ),
-                                attributes: [
-                                    KeyValue {
-                                        key: "connection.state",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "Open",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.json_schema",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "{}",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.id",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        2,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "thread.name",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "test_grpc_protobuf_export",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.filepath",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "/home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/h2-0.4.12/src/proto/connection.rs",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.lineno",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    IntValue(
-                                                        273,
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "code.namespace",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "h2::proto::connection",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ],
-                                dropped_attributes_count: 0,
-                                flags: 1,
-                                trace_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    241,
-                                ],
-                                span_id: [
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    242,
-                                ],
-                                event_name: "",
-                            },
-                        ],
-                        schema_url: "",
-                    },
-                ],
-                schema_url: "",
-            },
-        ],
+    for log_request in &mut log_requests {
+        make_log_request_deterministic(log_request);
     }
+
+    assert_debug_snapshot!(log_requests, @r#"
+    [
+        ExportLogsServiceRequest {
+            resource_logs: [
+                ResourceLogs {
+                    resource: Some(
+                        Resource {
+                            attributes: [
+                                KeyValue {
+                                    key: "service.name",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "unknown_service",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.language",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "rust",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.name",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "opentelemetry",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                                KeyValue {
+                                    key: "telemetry.sdk.version",
+                                    value: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "0.30.0",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                            dropped_attributes_count: 0,
+                            entity_refs: [],
+                        },
+                    ),
+                    scope_logs: [
+                        ScopeLogs {
+                            scope: Some(
+                                InstrumentationScope {
+                                    name: "logfire",
+                                    version: "",
+                                    attributes: [],
+                                    dropped_attributes_count: 0,
+                                },
+                            ),
+                            log_records: [
+                                LogRecord {
+                                    time_unix_nano: 0,
+                                    observed_time_unix_nano: 0,
+                                    severity_number: Info,
+                                    severity_text: "INFO",
+                                    body: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "Test log message outside span",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    attributes: [
+                                        KeyValue {
+                                            key: "code.filepath",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "tests/test_grpc_sink.rs",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.lineno",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            188,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.namespace",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_sink",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.json_schema",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "{\"type\":\"object\",\"properties\":{}}",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.id",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            0,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.name",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_protobuf_export",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    dropped_attributes_count: 0,
+                                    flags: 0,
+                                    trace_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    ],
+                                    span_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                    ],
+                                    event_name: "Test log message outside span",
+                                },
+                                LogRecord {
+                                    time_unix_nano: 1000000000,
+                                    observed_time_unix_nano: 1000000000,
+                                    severity_number: Info,
+                                    severity_text: "INFO",
+                                    body: Some(
+                                        AnyValue {
+                                            value: Some(
+                                                StringValue(
+                                                    "Test log message from within span",
+                                                ),
+                                            ),
+                                        },
+                                    ),
+                                    attributes: [
+                                        KeyValue {
+                                            key: "code.filepath",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "tests/test_grpc_sink.rs",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.lineno",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            190,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "code.namespace",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_sink",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "logfire.json_schema",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "{\"type\":\"object\",\"properties\":{}}",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.id",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        IntValue(
+                                                            0,
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        KeyValue {
+                                            key: "thread.name",
+                                            value: Some(
+                                                AnyValue {
+                                                    value: Some(
+                                                        StringValue(
+                                                            "test_grpc_protobuf_export",
+                                                        ),
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                    dropped_attributes_count: 0,
+                                    flags: 1,
+                                    trace_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        240,
+                                    ],
+                                    span_id: [
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        0,
+                                        240,
+                                    ],
+                                    event_name: "Test log message from within span",
+                                },
+                            ],
+                            schema_url: "",
+                        },
+                    ],
+                    schema_url: "",
+                },
+            ],
+        },
+    ]
     "#);
 }
 

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -1,5 +1,5 @@
 //! Integration tests for gRPC sink with mock server.
-// #![cfg(feature = "export-grpc")]
+#![cfg(feature = "export-grpc")]
 
 use futures::channel::oneshot;
 use insta::assert_debug_snapshot;


### PR DESCRIPTION
This solves the problem of `opentelemetry` sdk's dependendencies calling into `tracing` in the export process. The way this is done is by moving to use the `async` exporters in a background tokio runtime which suppresses all telemetry.

In particular this leads to a much nicer experience on DEBUG level or lower, where previously there would be endless exports sending logs about http connections to logfire's servers (etc).