### PR TITLE
implement `service_name`, `service_version`, and `deployment_environment` config builders

### DIFF
--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -2328,20 +2328,18 @@ mod tests {
         assert_debug_snapshot!(metrics, @r#"
         [
             DeterministicResourceMetrics {
-                resource: Resource {
-                    inner: ResourceInner {
-                        attrs: {
+                resource: [
+                    KeyValue {
+                        key: Static(
+                            "service.name",
+                        ),
+                        value: String(
                             Static(
-                                "service.name",
-                            ): String(
-                                Static(
-                                    "test",
-                                ),
+                                "test",
                             ),
-                        },
-                        schema_url: None,
+                        ),
                     },
-                },
+                ],
                 scope_metrics: [
                     DeterministicScopeMetrics {
                         scope: InstrumentationScope {
@@ -2376,20 +2374,18 @@ mod tests {
                 ],
             },
             DeterministicResourceMetrics {
-                resource: Resource {
-                    inner: ResourceInner {
-                        attrs: {
+                resource: [
+                    KeyValue {
+                        key: Static(
+                            "service.name",
+                        ),
+                        value: String(
                             Static(
-                                "service.name",
-                            ): String(
-                                Static(
-                                    "test",
-                                ),
+                                "test",
                             ),
-                        },
-                        schema_url: None,
+                        ),
                     },
-                },
+                ],
                 scope_metrics: [
                     DeterministicScopeMetrics {
                         scope: InstrumentationScope {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,9 +26,9 @@ pub struct LogfireConfigBuilder {
     pub(crate) local: bool,
     pub(crate) send_to_logfire: Option<SendToLogfire>,
     pub(crate) token: Option<String>,
-    // service_name: Option<String>,
-    // service_version: Option<String>,
-    // environment: Option<String>,
+    pub(crate) service_name: Option<String>,
+    pub(crate) service_version: Option<String>,
+    pub(crate) environment: Option<String>,
     pub(crate) console_options: Option<ConsoleOptions>,
 
     // config_dir: Option<PathBuf>,
@@ -83,6 +83,30 @@ impl LogfireConfigBuilder {
     /// Defaults to the value of `LOGFIRE_TOKEN` if set.
     pub fn with_token<T: Into<String>>(mut self, token: T) -> Self {
         self.token = Some(token.into());
+        self
+    }
+
+    /// Set the [service name] for the application.
+    ///
+    /// [service name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name
+    pub fn with_service_name<T: Into<String>>(mut self, service_name: T) -> Self {
+        self.service_name = Some(service_name.into());
+        self
+    }
+
+    /// Set the [service version] for the application.
+    ///
+    /// [service version]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-version
+    pub fn with_service_version<T: Into<String>>(mut self, service_version: T) -> Self {
+        self.service_version = Some(service_version.into());
+        self
+    }
+
+    /// Set the [deployment environment] for the application.
+    ///
+    /// [deployment environment]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-environment-name
+    pub fn with_environment<T: Into<String>>(mut self, environment: T) -> Self {
+        self.environment = Some(environment.into());
         self
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use opentelemetry::{
-    InstrumentationScope, Value,
+    InstrumentationScope, KeyValue, Value,
     logs::{LogRecord, Logger, LoggerProvider as _},
     trace::{SpanId, TraceId},
 };
@@ -189,13 +189,23 @@ pub fn remap_timestamps_in_console_output(output: &str) -> Cow<'_, str> {
     })
 }
 
+/// `Resource` contains a hashmap, so deterministic tests need to convert to an ordered container.
+fn make_deterministic_resource(resource: &Resource) -> Vec<KeyValue> {
+    let mut attrs: Vec<_> = resource
+        .iter()
+        .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
+        .collect();
+    attrs.sort_by_key(|kv| kv.key.clone());
+    attrs
+}
+
 pub fn make_deterministic_resource_metrics(
     metrics: Vec<ResourceMetrics>,
 ) -> Vec<DeterministicResourceMetrics> {
     metrics
         .into_iter()
         .map(|metric| DeterministicResourceMetrics {
-            resource: metric.resource().clone(),
+            resource: make_deterministic_resource(&metric.resource()),
             scope_metrics: metric
                 .scope_metrics()
                 .map(|scope_metric| DeterministicScopeMetrics {
@@ -261,7 +271,7 @@ pub struct DeterministicMetric {
 /// Deterministic resource metrics
 #[derive(Debug)]
 pub struct DeterministicResourceMetrics {
-    resource: Resource,
+    resource: Vec<KeyValue>,
     scope_metrics: Vec<DeterministicScopeMetrics>,
 }
 

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -1586,13 +1586,12 @@ async fn test_basic_metrics() {
 
     let logfire = logfire::configure()
         .send_to_logfire(false)
+        .with_service_name("test-service")
+        .with_service_version("1.2.3")
+        .with_environment("test")
         .with_metrics(Some(
             MetricsOptions::default().with_additional_reader(reader.clone()),
         ))
-        .with_advanced_options(
-            AdvancedOptions::default()
-                .with_resource(Resource::builder_empty().with_service_name("test").build()),
-        )
         .finish()
         .unwrap();
 
@@ -1621,20 +1620,38 @@ async fn test_basic_metrics() {
     assert_debug_snapshot!(metrics, @r#"
     [
         DeterministicResourceMetrics {
-            resource: Resource {
-                inner: ResourceInner {
-                    attrs: {
-                        Static(
-                            "service.name",
-                        ): String(
-                            Static(
-                                "test",
-                            ),
+            resource: [
+                KeyValue {
+                    key: Static(
+                        "deployment.environment.name",
+                    ),
+                    value: String(
+                        Owned(
+                            "test",
                         ),
-                    },
-                    schema_url: None,
+                    ),
                 },
-            },
+                KeyValue {
+                    key: Static(
+                        "service.name",
+                    ),
+                    value: String(
+                        Owned(
+                            "test-service",
+                        ),
+                    ),
+                },
+                KeyValue {
+                    key: Static(
+                        "service.version",
+                    ),
+                    value: String(
+                        Owned(
+                            "1.2.3",
+                        ),
+                    ),
+                },
+            ],
             scope_metrics: [
                 DeterministicScopeMetrics {
                     scope: InstrumentationScope {
@@ -1655,20 +1672,38 @@ async fn test_basic_metrics() {
             ],
         },
         DeterministicResourceMetrics {
-            resource: Resource {
-                inner: ResourceInner {
-                    attrs: {
-                        Static(
-                            "service.name",
-                        ): String(
-                            Static(
-                                "test",
-                            ),
+            resource: [
+                KeyValue {
+                    key: Static(
+                        "deployment.environment.name",
+                    ),
+                    value: String(
+                        Owned(
+                            "test",
                         ),
-                    },
-                    schema_url: None,
+                    ),
                 },
-            },
+                KeyValue {
+                    key: Static(
+                        "service.name",
+                    ),
+                    value: String(
+                        Owned(
+                            "test-service",
+                        ),
+                    ),
+                },
+                KeyValue {
+                    key: Static(
+                        "service.version",
+                    ),
+                    value: String(
+                        Owned(
+                            "1.2.3",
+                        ),
+                    ),
+                },
+            ],
             scope_metrics: [
                 DeterministicScopeMetrics {
                     scope: InstrumentationScope {


### PR DESCRIPTION
Makes experience of using the SDK a bit cleaner.