### PR TITLE
handle panics by default

### DIFF
--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -50,7 +50,6 @@ struct CreateUserRequest {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Logfire
     let logfire = logfire::configure()
-        .install_panic_handler()
         .finish()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     let _guard = logfire.shutdown_guard();

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -59,7 +59,7 @@ struct CreateUserRequest {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize Logfire
-    let logfire = logfire::configure().install_panic_handler().finish()?;
+    let logfire = logfire::configure().finish()?;
     let _guard = logfire.shutdown_guard();
 
     logfire::info!("Starting Axum server with Logfire integration");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -15,7 +15,7 @@ static FILES_COUNTER: LazyLock<Counter<u64>> = LazyLock::new(|| {
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() -> Result<()> {
-    let logfire = logfire::configure().install_panic_handler().finish()?;
+    let logfire = logfire::configure().finish()?;
     let _guard = logfire.shutdown_guard();
 
     let mut total_size = 0u64;

--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -81,7 +81,6 @@ mod tests {
         let logfire = crate::configure()
             .local()
             .send_to_logfire(false)
-            .install_panic_handler()
             .with_default_level_filter(TracingLevelFilter::TRACE)
             .with_advanced_options(
                 AdvancedOptions::default()
@@ -179,7 +178,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        26,
+                                        25,
                                     ),
                                 ),
                             ),
@@ -312,7 +311,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        27,
+                                        26,
                                     ),
                                 ),
                             ),
@@ -445,7 +444,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        30,
+                                        29,
                                     ),
                                 ),
                             ),
@@ -578,7 +577,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        31,
+                                        30,
                                     ),
                                 ),
                             ),
@@ -711,7 +710,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        32,
+                                        31,
                                     ),
                                 ),
                             ),
@@ -844,7 +843,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        33,
+                                        32,
                                     ),
                                 ),
                             ),
@@ -977,7 +976,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        34,
+                                        33,
                                     ),
                                 ),
                             ),
@@ -1065,7 +1064,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options.clone()))
-            .install_panic_handler()
             .with_default_level_filter(TracingLevelFilter::TRACE)
             .finish()
             .unwrap();

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -535,7 +535,6 @@ mod tests {
                 .with_additional_span_processor(SimpleSpanProcessor::new(
                     DeterministicExporter::new(exporter.clone(), TEST_FILE, TEST_LINE),
                 ))
-                .install_panic_handler()
                 .with_default_level_filter(LevelFilter::TRACE)
                 .with_advanced_options(
                     AdvancedOptions::default()
@@ -613,7 +612,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            28,
+                            27,
                         ),
                     },
                     KeyValue {
@@ -719,7 +718,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            29,
+                            28,
                         ),
                     },
                     KeyValue {
@@ -835,7 +834,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            29,
+                            28,
                         ),
                     },
                     KeyValue {
@@ -957,7 +956,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            30,
+                            29,
                         ),
                     },
                     KeyValue {
@@ -1073,7 +1072,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            30,
+                            29,
                         ),
                     },
                     KeyValue {
@@ -1195,7 +1194,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            31,
+                            30,
                         ),
                     },
                     KeyValue {
@@ -1311,7 +1310,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            31,
+                            30,
                         ),
                     },
                     KeyValue {
@@ -1433,7 +1432,7 @@ mod tests {
                             "code.lineno",
                         ),
                         value: I64(
-                            28,
+                            27,
                         ),
                     },
                     KeyValue {
@@ -1573,7 +1572,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        25,
+                                        24,
                                     ),
                                 ),
                             ),
@@ -1706,7 +1705,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        26,
+                                        25,
                                     ),
                                 ),
                             ),
@@ -1849,7 +1848,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        33,
+                                        32,
                                     ),
                                 ),
                             ),
@@ -1982,7 +1981,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        34,
+                                        33,
                                     ),
                                 ),
                             ),
@@ -2082,7 +2081,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options.clone()))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -2138,7 +2136,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::INFO)
             .finish()
             .unwrap();
@@ -2278,7 +2275,6 @@ mod tests {
             .with_metrics(Some(
                 crate::config::MetricsOptions::default().with_additional_reader(reader.clone()),
             ))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .with_advanced_options(
                 AdvancedOptions::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,6 @@ use tracing::{Level, level_filters::LevelFilter};
 use crate::{ConfigureError, logfire::Logfire};
 
 /// Builder for logfire configuration, returned from [`logfire::configure()`][crate::configure].
-#[derive(Default)]
 #[must_use = "call `.finish()` to complete logfire configuration."]
 pub struct LogfireConfigBuilder {
     pub(crate) local: bool,
@@ -52,6 +51,23 @@ pub struct LogfireConfigBuilder {
     pub(crate) default_level_filter: Option<LevelFilter>,
 }
 
+impl Default for LogfireConfigBuilder {
+    fn default() -> Self {
+        Self {
+            local: false,
+            send_to_logfire: None,
+            token: None,
+            console_options: None,
+            data_dir: None,
+            additional_span_processors: Vec::new(),
+            advanced: None,
+            metrics: None,
+            install_panic_handler: true,
+            default_level_filter: None,
+        }
+    }
+}
+
 impl LogfireConfigBuilder {
     /// Call to configure Logfire for local use only.
     ///
@@ -62,11 +78,17 @@ impl LogfireConfigBuilder {
         self
     }
 
-    /// Call to install a hook to log panics.
+    /// Whether to install a hook to
     ///
     /// Any existing panic hook will be preserved and called after the logfire panic hook.
-    pub fn install_panic_handler(mut self) -> Self {
-        self.install_panic_handler = true;
+    pub fn with_install_panic_handler(mut self, install: bool) -> Self {
+        self.install_panic_handler = install;
+        self
+    }
+
+    /// Deprecated form of [`with_install_panic_handler`][Self::with_install_panic_handler].
+    #[deprecated(since = "0.8.0", note = "noop; now installed by default")]
+    pub fn install_panic_handler(self) -> Self {
         self
     }
 

--- a/src/internal/exporters/console.rs
+++ b/src/internal/exporters/console.rs
@@ -410,7 +410,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -457,7 +456,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -503,7 +501,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -541,7 +538,6 @@ mod tests {
         let shutdown_handler = crate::configure()
             .send_to_logfire(false)
             .local()
-            .install_panic_handler()
             .finish()
             .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@
 //! ```rust
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let logfire = logfire::configure()
-//!         .install_panic_handler()
 //! #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
 //!         .finish()?;
 //!
@@ -186,7 +185,6 @@ pub enum ShutdownError {
 /// ```rust
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let logfire = logfire::configure()
-///         .install_panic_handler()
 /// #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
 ///         .finish()?;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use macros::*;
 pub use metrics::*;
 
 pub use crate::bridges::tracing::LogfireTracingLayer;
-pub use crate::logfire::Logfire;
+pub use crate::logfire::{Logfire, ShutdownGuard};
 
 mod internal;
 

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -62,7 +62,6 @@ impl Logfire {
     /// ```rust
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let logfire = logfire::configure()
-    ///         .install_panic_handler()
     /// #        .send_to_logfire(logfire::config::SendToLogfire::IfTokenPresent)
     ///         .finish()?;
     ///
@@ -916,5 +915,37 @@ mod tests {
             assert!(matches!(e, crate::ConfigureError::TokenRequired));
         }
         // temp_dir is cleaned up automatically
+    }
+
+    #[test]
+    fn test_panic_handler_disabled() {
+        // other tests check enabled (default)
+
+        use crate::config::AdvancedOptions;
+        use opentelemetry_sdk::logs::{InMemoryLogExporter, SimpleLogProcessor};
+
+        let log_exporter = InMemoryLogExporter::default();
+
+        let logfire = configure()
+            .local()
+            .send_to_logfire(false)
+            .with_install_panic_handler(false)
+            .with_advanced_options(
+                AdvancedOptions::default()
+                    .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
+            )
+            .finish()
+            .expect("failed to configure logfire");
+
+        let guard = crate::set_local_logfire(logfire);
+
+        let _result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            panic!("test panic");
+        }));
+
+        guard.shutdown().expect("shutdown should succeed");
+
+        let logs = log_exporter.get_emitted_logs().unwrap();
+        assert!(logs.is_empty());
     }
 }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -287,7 +287,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -319,7 +318,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -351,7 +349,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -383,7 +380,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -415,7 +411,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -447,7 +442,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();
@@ -479,7 +473,6 @@ mod tests {
             .local()
             .send_to_logfire(false)
             .with_console(Some(console_options))
-            .install_panic_handler()
             .with_default_level_filter(tracing::level_filters::LevelFilter::TRACE)
             .finish()
             .unwrap();

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -57,6 +57,15 @@
 //! span.record("my_attr", "some value");
 //! ```
 //!
+//! # Handling panics
+//!
+//! By default, the Logfire SDK will install a [panic hook][std::panic::set_hook] to record panics as error logs.
+//!
+//! In the case that the panic is causing the application to fully unwind and exit, you should
+//! ensure that there is a [`ShutdownGuard`][crate::ShutdownGuard] installed on your application's main stack frame.
+//!
+//! All [examples] follow this best-practice.
+//!
 //! # Using `logfire` as a layer in an existing `tracing` application
 //!
 //! If you have an existing application which already has a [`tracing_subscriber`] and you
@@ -73,20 +82,22 @@
 //! // 1. configure logfire as usual, setting it as a `.local()` instance
 //! let logfire = logfire::configure()
 //!     .local()
-//!     .install_panic_handler()
 //!     .finish()?;
 //!
-//! // 2. create a tracing subscriber
+//! // 2. add a logfire shutdown guard for panics
+//! let _guard = logfire.shutdown_guard();
+//!
+//! // 3. create a tracing subscriber
 //! let subscriber = tracing_subscriber::registry()
 //!     .with(logfire.tracing_layer());
 //!
-//! // 3. set the subscriber as the default (or otherwise set it up for your application)
+//! // 4. set the subscriber as the default (or otherwise set it up for your application)
 //! tracing::subscriber::set_global_default(subscriber)?;
 //!
-//! // 4. now tracing's spans and logs will be sent to Logfire
+//! // 5. now tracing's spans and logs will be sent to Logfire
 //! tracing::info!("This will be sent to Logfire");
 //!
-//! // 5. when finished, call logfire.shutdown() to flush and clean up
+//! // 6. when finished, call logfire.shutdown() to flush and clean up
 //! logfire.shutdown()?;
 //! # Ok(())
 //! # }

--- a/src/usage/mod.rs
+++ b/src/usage/mod.rs
@@ -85,7 +85,7 @@
 //!     .finish()?;
 //!
 //! // 2. add a logfire shutdown guard for panics
-//! let _guard = logfire.shutdown_guard();
+//! let _guard = logfire.clone().shutdown_guard();
 //!
 //! // 3. create a tracing subscriber
 //! let subscriber = tracing_subscriber::registry()

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -45,7 +45,6 @@ fn test_basic_span() {
             TEST_FILE,
             TEST_LINE,
         )))
-        .install_panic_handler()
         .with_default_level_filter(LevelFilter::TRACE)
         .with_advanced_options(
             AdvancedOptions::default()
@@ -128,7 +127,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        33,
+                        32,
                     ),
                 },
                 KeyValue {
@@ -254,7 +253,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -410,7 +409,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        34,
+                        33,
                     ),
                 },
                 KeyValue {
@@ -572,7 +571,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -708,7 +707,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        35,
+                        34,
                     ),
                 },
                 KeyValue {
@@ -850,7 +849,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        36,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -986,7 +985,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        36,
+                        35,
                     ),
                 },
                 KeyValue {
@@ -1128,7 +1127,7 @@ fn test_basic_span() {
                         "code.lineno",
                     ),
                     value: I64(
-                        33,
+                        32,
                     ),
                 },
                 KeyValue {
@@ -1302,7 +1301,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    37,
+                                    36,
                                 ),
                             ),
                         ),
@@ -1457,7 +1456,7 @@ fn test_basic_span() {
                                     "code.lineno",
                                 ),
                                 Int(
-                                    38,
+                                    37,
                                 ),
                             ),
                         ),


### PR DESCRIPTION
Removes the need for users to call `install_panic_handler()`, instead they can opt-out with `.with_install_panic_handler(false)`.