### PR TITLE
make macros hygienic

### DIFF
--- a/src/bridges/log.rs
+++ b/src/bridges/log.rs
@@ -102,12 +102,14 @@ mod tests {
         log::info!(logger: lf_logger, "root event");
         log::info!(logger: lf_logger, target: "custom_target", "root event with target");
 
-        let _root = tracing::span!(tracing::Level::INFO, "root span").entered();
+        let root = tracing::span!(tracing::Level::INFO, "root span").entered();
         log::info!(logger: lf_logger, "hello world log");
         log::warn!(logger: lf_logger, "warning log");
         log::error!(logger: lf_logger, "error log");
         log::debug!(logger: lf_logger, "debug log");
         log::trace!(logger: lf_logger, "trace log");
+
+        drop(root);
 
         let logs = log_exporter.get_emitted_logs().unwrap();
 

--- a/src/macros/impl_.rs
+++ b/src/macros/impl_.rs
@@ -16,13 +16,16 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 // them at the crate root.
 pub use crate::{__log as log, __tracing_span as tracing_span};
 
+// Private re-export of `tracing` components, because the macros depend upon it.
+pub use tracing::{Level, Span, span as __tracing_span_impl};
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __tracing_span {
     (parent: $parent:expr, $level:expr, $format:expr, $($($path:ident).+ $(= $value:expr)?),*) => {{
         // bind args early to avoid multiple evaluation
         $crate::__bind_single_ident_args!($($($path).+ $(= $value)?),*);
-        tracing::span!(
+        $crate::__macros_impl::__tracing_span_impl!(
             parent: $parent,
             $level,
             $format,
@@ -34,7 +37,7 @@ macro_rules! __tracing_span {
     ($level:expr, $format:expr, $($($path:ident).+ $(= $value:expr)?),*) => {{
         // bind args early to avoid multiple evaluation
         $crate::__bind_single_ident_args!($($($path).+ $(= $value)?),*);
-        tracing::span!(
+        $crate::__macros_impl::__tracing_span_impl!(
             $level,
             $format,
             $($($path).+ = $crate::__evaluate_arg!($($path).+ $(= $value)?),)*
@@ -261,12 +264,12 @@ macro_rules! __log {
             $crate::__macros_impl::export_log(
                 $format,
                 &$parent,
-                format!($format),
+                ::std::format!($format),
                 $level,
                 $crate::__json_schema!($($($path).+),*),
-                Some(::std::borrow::Cow::Borrowed(file!())),
-                Some(line!()),
-                Some(module_path!()),
+                ::std::option::Option::Some(::std::borrow::Cow::Borrowed(file!())),
+                ::std::option::Option::Some(line!()),
+                ::std::option::Option::Some(module_path!()),
                 [
                     $({
                         let arg_value = $crate::__evaluate_arg!($($path).+ $(= $value)?);

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -90,13 +90,13 @@ macro_rules! span {
         $crate::__macros_impl::tracing_span!(parent: $parent, $level, $format, $($($path).+ $(= $value)?),*)
     };
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
+        $crate::__macros_impl::tracing_span!(parent: $parent, $crate::__macros_impl::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
     (level: $level:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
         $crate::__macros_impl::tracing_span!($level, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::__macros_impl::tracing_span!(tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
+        $crate::__macros_impl::tracing_span!($crate::__macros_impl::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -106,10 +106,10 @@ macro_rules! span {
 #[macro_export]
 macro_rules! error {
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!(parent: $parent, $crate::__macros_impl::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(tracing::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!($crate::__macros_impl::Level::ERROR, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -119,10 +119,10 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::WARN, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!(parent: $parent, $crate::__macros_impl::Level::WARN, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(tracing::Level::WARN, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!($crate::__macros_impl::Level::WARN, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -132,10 +132,10 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!(parent: $parent, $crate::__macros_impl::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(tracing::Level::INFO, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!($crate::__macros_impl::Level::INFO, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -145,10 +145,10 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!(parent: $parent, $crate::__macros_impl::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(tracing::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!($crate::__macros_impl::Level::DEBUG, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -158,10 +158,10 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     (parent: $parent:expr, $format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(parent: $parent, tracing::Level::TRACE, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!(parent: $parent, $crate::__macros_impl::Level::TRACE, $format, $($($path).+ $(= $value)?),*)
     };
     ($format:expr $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::log!(tracing::Level::TRACE, $format, $($($path).+ $(= $value)?),*)
+        $crate::log!($crate::__macros_impl::Level::TRACE, $format, $($($path).+ $(= $value)?),*)
     };
 }
 
@@ -265,7 +265,7 @@ macro_rules! log {
         $crate::__macros_impl::log!(parent: $parent, $level, $format, $($($path).+ $(= $value)?),*)
     };
     ($level:expr, $format:expr  $(, $($path:ident).+ $(= $value:expr)?)* $(,)?) => {
-        $crate::__macros_impl::log!(parent: tracing::Span::current(), $level, $format, $($($path).+ $(= $value)?),*)
+        $crate::__macros_impl::log!(parent: $crate::__macros_impl::Span::current(), $level, $format, $($($path).+ $(= $value)?),*)
     };
 }
 

--- a/tests/test_macro_hygiene.rs
+++ b/tests/test_macro_hygiene.rs
@@ -1,0 +1,15 @@
+#![no_implicit_prelude]
+//! Tests that logfire macros compile without external dependencies.
+
+#[test]
+fn test_macros() {
+    // If the macros are not hygienic, they will fail to compile due to the
+    // use of `no_implicit_prelude` above.
+    ::logfire::span!("Test span");
+
+    ::logfire::trace!("Test trace");
+    ::logfire::debug!("Test debug");
+    ::logfire::info!("Test info");
+    ::logfire::warn!("Test warn");
+    ::logfire::error!("Test error");
+}


### PR DESCRIPTION
This helps ensure that the basic quick-start just works without any additional dependencies; at the moment `tracing` is needed but it's not documented as such. :/