### PR TITLE
add more `LogfireConverter`

### DIFF
--- a/examples/actix-web.rs
+++ b/examples/actix-web.rs
@@ -89,28 +89,22 @@ async fn root() -> HttpResponse {
 async fn get_user(path: web::Path<u32>) -> ActixResult<HttpResponse> {
     let user_id = path.into_inner();
     async {
-        logfire::info!("Fetching user with ID: {user_id}", user_id = user_id as i64);
+        logfire::info!("Fetching user with ID: {user_id}");
 
         // Simulate database lookup
         tokio::time::sleep(std::time::Duration::from_millis(10))
             .instrument(logfire::span!("Database query for user"))
             .await;
 
-        logfire::debug!(
-            "Database query completed for user {user_id}",
-            user_id = user_id as i64
-        );
+        logfire::debug!("Database query completed for user {user_id}");
 
         if user_id == 0 {
-            logfire::warn!(
-                "Invalid user ID requested: {user_id}",
-                user_id = user_id as i64
-            );
+            logfire::warn!("Invalid user ID requested: {user_id}");
             return Ok(HttpResponse::BadRequest().finish());
         }
 
         if user_id > 1000 {
-            logfire::error!("User {user_id} not found", user_id = user_id as i64);
+            logfire::error!("User {user_id} not found");
             return Ok(HttpResponse::NotFound().finish());
         }
 
@@ -120,10 +114,7 @@ async fn get_user(path: web::Path<u32>) -> ActixResult<HttpResponse> {
             email: format!("user{user_id}@example.com"),
         };
 
-        logfire::info!(
-            "Successfully retrieved user {user_id}",
-            user_id = user_id as i64
-        );
+        logfire::info!("Successfully retrieved user {user_id}");
 
         Ok(HttpResponse::Ok().json(user))
     }
@@ -158,7 +149,7 @@ async fn create_user(payload: web::Json<CreateUserRequest>) -> ActixResult<HttpR
 
         logfire::info!(
             "Successfully created user {id} with name {name}",
-            id = user.id as i64,
+            id = user.id,
             name = &user.name
         );
 

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -102,28 +102,22 @@ async fn root() -> &'static str {
 
 async fn get_user(Path(user_id): Path<u32>) -> Result<Json<User>, StatusCode> {
     async {
-        logfire::info!("Fetching user with ID: {user_id}", user_id = user_id as i64);
+        logfire::info!("Fetching user with ID: {user_id}");
 
         // Simulate database lookup
         tokio::time::sleep(std::time::Duration::from_millis(10))
             .instrument(logfire::span!("Database query for user"))
             .await;
 
-        logfire::debug!(
-            "Database query completed for user {user_id}",
-            user_id = user_id as i64
-        );
+        logfire::debug!("Database query completed for user {user_id}",);
 
         if user_id == 0 {
-            logfire::warn!(
-                "Invalid user ID requested: {user_id}",
-                user_id = user_id as i64
-            );
+            logfire::warn!("Invalid user ID requested: {user_id}",);
             return Err(StatusCode::BAD_REQUEST);
         }
 
         if user_id > 1000 {
-            logfire::error!("User {user_id} not found", user_id = user_id as i64);
+            logfire::error!("User {user_id} not found");
             return Err(StatusCode::NOT_FOUND);
         }
 
@@ -133,14 +127,11 @@ async fn get_user(Path(user_id): Path<u32>) -> Result<Json<User>, StatusCode> {
             email: format!("user{user_id}@example.com"),
         };
 
-        logfire::info!(
-            "Successfully retrieved user {user_id}",
-            user_id = user_id as i64
-        );
+        logfire::info!("Successfully retrieved user {user_id}",);
 
         Ok(Json(user))
     }
-    .instrument(logfire::span!("Fetching user {user_id}", user_id = user_id))
+    .instrument(logfire::span!("Fetching user {user_id}"))
     .await
 }
 
@@ -173,7 +164,7 @@ async fn create_user(
 
         logfire::info!(
             "Successfully created user {id} with name {name}",
-            id = user.id as i64,
+            id = user.id,
             name = &user.name
         );
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
     logfire::info!(
         "total size of {cwd} is {size} bytes",
         cwd = cwd.display().to_string(),
-        size = total_size as i64
+        size = total_size
     );
 
     Ok(())


### PR DESCRIPTION
This adds more `LogfireConverter` to address #58, and many other types.

I also took the liberty to update the test of the macro a bit, to avoid repetition, and added tests for many rust types for `log!`

The examples also update to show that you can actually use any time. 