### PR TITLE
Move to `opentelemetry` `0.31`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ env_filter = "0.1"
 
 # deps for grpc export
 http = { version = "1.2", optional = true }
-tonic = { version = "0.13", optional = true }
+tonic = { version = "0.14", optional = true }
 
 rand = "0.9.0"
 
@@ -70,9 +70,9 @@ tokio = { version = "1.44.1", features = [
 ] }
 ulid = "1.2.0"
 wiremock = "=0.6.4"
-tonic-build = "0.13"
-tonic = { version = "0.13", features = ["transport"] }
-prost = "0.13"
+tonic-build = "0.14"
+tonic = { version = "0.14", features = ["transport"] }
+prost = "0.14"
 opentelemetry-proto = { version = "0.31", features = [
     "tonic",
     "gen-tonic-messages",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ tonic = { version = "0.13", optional = true }
 
 rand = "0.9.0"
 
-opentelemetry = { version = "0.30", default-features = false, features = [
+opentelemetry = { version = "0.31", default-features = false, features = [
     "trace",
     "logs",
 ] }
-opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
     "trace",
     "experimental_metrics_custom_reader",
     "experimental_trace_batch_span_processor_with_async_runtime",
@@ -33,7 +33,7 @@ opentelemetry_sdk = { version = "0.30", default-features = false, features = [
     "logs",
     "spec_unstable_metrics_views"
 ] }
-opentelemetry-otlp = { version = "0.30", default-features = false, features = [
+opentelemetry-otlp = { version = "0.31", default-features = false, features = [
     "trace",
     "metrics",
     "logs",
@@ -45,7 +45,7 @@ tokio = { version = "1.44.1", default-features = false, features = [
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-opentelemetry = "0.31"
+tracing-opentelemetry = { git = "https://github.com/marc-pydantic/tracing-opentelemetry", branch = "marc/opentelemetry-0.31" }
 
 thiserror = "2"
 
@@ -59,7 +59,7 @@ regex = "1.11.1"
 async-trait = "0.1.88"
 futures = { version = "0.3.31", features = ["futures-executor"] }
 insta = "1.42.1"
-opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
     "testing",
 ] }
 regex = "1.11.1"
@@ -73,7 +73,7 @@ wiremock = "=0.6.4"
 tonic-build = "0.13"
 tonic = { version = "0.13", features = ["transport"] }
 prost = "0.13"
-opentelemetry-proto = { version = "0.30", features = [
+opentelemetry-proto = { version = "0.31", features = [
     "tonic",
     "gen-tonic-messages",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1.44.1", default-features = false, features = [
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-opentelemetry = { git = "https://github.com/marc-pydantic/tracing-opentelemetry", branch = "marc/opentelemetry-0.31" }
+tracing-opentelemetry = { git = "https://github.com/pydantic/tracing-opentelemetry", branch = "marc/opentelemetry-0.31" }
 
 thiserror = "2"
 

--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -576,6 +576,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "root span",
                 start_time: SystemTime {
@@ -682,6 +683,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f2,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "hello world span",
                 start_time: SystemTime {
@@ -798,6 +800,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "hello world span",
                 start_time: SystemTime {
@@ -920,6 +923,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f4,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span",
                 start_time: SystemTime {
@@ -1036,6 +1040,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span",
                 start_time: SystemTime {
@@ -1158,6 +1163,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f6,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span with explicit parent",
                 start_time: SystemTime {
@@ -1274,6 +1280,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span with explicit parent",
                 start_time: SystemTime {
@@ -1396,6 +1403,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 0000000000000000,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "root span",
                 start_time: SystemTime {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -35,11 +35,13 @@ pub struct DeterministicIdGenerator {
 
 impl IdGenerator for DeterministicIdGenerator {
     fn new_trace_id(&self) -> opentelemetry::trace::TraceId {
-        TraceId::from_u128(self.next_trace_id.fetch_add(1, Ordering::Relaxed).into())
+        let id = self.next_trace_id.fetch_add(1, Ordering::Relaxed) as u128;
+        TraceId::from_bytes(id.to_be_bytes())
     }
 
     fn new_span_id(&self) -> opentelemetry::trace::SpanId {
-        SpanId::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed))
+        let id = self.next_span_id.fetch_add(1, Ordering::Relaxed);
+        SpanId::from_bytes(id.to_be_bytes())
     }
 }
 

--- a/tests/test_basic_exports.rs
+++ b/tests/test_basic_exports.rs
@@ -91,6 +91,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "root span",
             start_time: SystemTime {
@@ -217,6 +218,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f2,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "hello world span",
             start_time: SystemTime {
@@ -373,6 +375,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "hello world span",
             start_time: SystemTime {
@@ -535,6 +538,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f4,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "debug span",
             start_time: SystemTime {
@@ -671,6 +675,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "debug span",
             start_time: SystemTime {
@@ -813,6 +818,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f6,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "debug span with explicit parent",
             start_time: SystemTime {
@@ -949,6 +955,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "debug span with explicit parent",
             start_time: SystemTime {
@@ -1091,6 +1098,7 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 0000000000000000,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "root span",
             start_time: SystemTime {

--- a/tests/test_grpc_sink.rs
+++ b/tests/test_grpc_sink.rs
@@ -254,7 +254,7 @@ async fn test_grpc_protobuf_export() {
                                         AnyValue {
                                             value: Some(
                                                 StringValue(
-                                                    "0.30.0",
+                                                    "0.31.0",
                                                 ),
                                             ),
                                         },
@@ -307,7 +307,7 @@ async fn test_grpc_protobuf_export() {
                                     ],
                                     trace_state: "",
                                     parent_span_id: [],
-                                    flags: 1,
+                                    flags: 257,
                                     name: "grpc_test_span",
                                     kind: Internal,
                                     start_time_unix_nano: 0,
@@ -523,7 +523,7 @@ async fn test_grpc_protobuf_export() {
                                         AnyValue {
                                             value: Some(
                                                 StringValue(
-                                                    "0.30.0",
+                                                    "0.31.0",
                                                 ),
                                             ),
                                         },

--- a/tests/test_http_sink.rs
+++ b/tests/test_http_sink.rs
@@ -114,7 +114,7 @@ async fn test_http_protobuf_export() {
                                     AnyValue {
                                         value: Some(
                                             StringValue(
-                                                "0.30.0",
+                                                "0.31.0",
                                             ),
                                         ),
                                     },
@@ -167,7 +167,7 @@ async fn test_http_protobuf_export() {
                                 ],
                                 trace_state: "",
                                 parent_span_id: [],
-                                flags: 1,
+                                flags: 257,
                                 name: "test_span",
                                 kind: Internal,
                                 start_time_unix_nano: 0,
@@ -430,7 +430,7 @@ async fn test_http_json_export() {
                                     AnyValue {
                                         value: Some(
                                             StringValue(
-                                                "0.30.0",
+                                                "0.31.0",
                                             ),
                                         ),
                                     },
@@ -483,7 +483,7 @@ async fn test_http_json_export() {
                                 ],
                                 trace_state: "",
                                 parent_span_id: [],
-                                flags: 1,
+                                flags: 257,
                                 name: "json_test_span",
                                 kind: Internal,
                                 start_time_unix_nano: 0,


### PR DESCRIPTION
(currently opening this to get a CI run)

The underlying `opentelemetry` should at some point migrate from `0.30` to `0.31`, if only to because some transitive dependencies have moved on, _e.g._ `prost`.

The `tracing-opentelemetry` crate had some unforced changes going from `0.30` to `0.31` (`opentelemetry` version, NOT `tracing-opentelemetry`, which confusingly is a one minor version ahead).

This branch is using a fork of `tracing-opentelemetry` that has manually seen its `opentelemetry` updated.