### PR TITLE
Add with_tracing_filter for custom/reloadable tracing filters

### DIFF
--- a/src/bridges/tracing.rs
+++ b/src/bridges/tracing.rs
@@ -8,7 +8,7 @@ use opentelemetry::{
 };
 use tracing::{Subscriber, field::Visit};
 use tracing_opentelemetry::{OtelData, PreSampledTracer};
-use tracing_subscriber::{EnvFilter, Layer, filter::Filtered, layer::Filter, registry::LookupSpan};
+use tracing_subscriber::{Layer, filter::Filtered, layer::Filter, registry::LookupSpan};
 
 use crate::{__macros_impl::LogfireValue, internal::logfire_tracer::LogfireTracer};
 
@@ -29,7 +29,7 @@ where
     pub(crate) fn new(
         tracer: LogfireTracer,
         enable_tracing_metrics: bool,
-        filter: Arc<EnvFilter>,
+        filter: Arc<dyn Filter<S> + Send + Sync + 'static>,
     ) -> Self {
         let otel_layer = tracing_opentelemetry::layer()
             .with_error_records_to_exceptions(true)
@@ -44,7 +44,7 @@ where
             metrics_layer,
         };
 
-        Self(inner.with_filter(filter as Arc<dyn Filter<S> + Send + Sync + 'static>))
+        Self(inner.with_filter(filter))
     }
 }
 
@@ -2477,5 +2477,147 @@ mod tests {
             },
         ]
         "#);
+    }
+
+    #[test]
+    fn test_with_tracing_filter_custom_filter() {
+        // Test that `with_tracing_filter` replaces the default EnvFilter
+        // and only passes events matching the custom filter.
+        let log_exporter = InMemoryLogExporter::default();
+
+        let logfire = crate::configure()
+            .local()
+            .send_to_logfire(false)
+            .with_advanced_options(
+                AdvancedOptions::default()
+                    .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
+            )
+            // Use a custom filter that only allows WARN and above
+            .with_tracing_filter(LevelFilter::WARN)
+            .finish()
+            .unwrap();
+
+        let guard = set_local_logfire(logfire);
+
+        {
+            tracing::trace!("trace event should be filtered");
+            tracing::debug!("debug event should be filtered");
+            tracing::info!("info event should be filtered");
+            tracing::warn!("warn event should pass");
+            tracing::error!("error event should pass");
+        }
+
+        guard.shutdown().unwrap();
+
+        let logs = log_exporter.get_emitted_logs().unwrap();
+        let log_bodies: Vec<String> = logs
+            .iter()
+            .filter_map(|l| l.record.body().map(|b| format!("{b:?}")))
+            .collect();
+
+        assert!(
+            !log_bodies.iter().any(|b| b.contains("info")),
+            "INFO event should have been filtered out, got: {log_bodies:?}"
+        );
+        assert!(
+            !log_bodies.iter().any(|b| b.contains("trace")),
+            "TRACE event should have been filtered out, got: {log_bodies:?}"
+        );
+        assert!(
+            log_bodies.iter().any(|b| b.contains("warn")),
+            "WARN event should have passed, got: {log_bodies:?}"
+        );
+        assert!(
+            log_bodies.iter().any(|b| b.contains("error")),
+            "ERROR event should have passed, got: {log_bodies:?}"
+        );
+    }
+
+    #[test]
+    fn test_with_tracing_filter_reload() {
+        // Test that a `reload::Layer` filter can be dynamically swapped
+        // from INFO down to DEBUG and back (the fusionfire use case).
+        use tracing_subscriber::{EnvFilter, reload};
+
+        let log_exporter = InMemoryLogExporter::default();
+
+        let initial_filter = EnvFilter::new("info");
+        let (filter, reload_handle) = reload::Layer::new(initial_filter);
+
+        let logfire = crate::configure()
+            .local()
+            .send_to_logfire(false)
+            .with_advanced_options(
+                AdvancedOptions::default()
+                    .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
+            )
+            .with_tracing_filter(filter)
+            .finish()
+            .unwrap();
+
+        let guard = set_local_logfire(logfire);
+
+        // Phase 1: filter is INFO — DEBUG events should be dropped
+        tracing::info!("info before reload");
+        tracing::debug!("debug before reload should be filtered");
+
+        // Phase 2: reload to DEBUG — DEBUG events should now pass
+        reload_handle
+            .modify(|f| *f = EnvFilter::new("debug"))
+            .unwrap();
+
+        tracing::info!("info after reload");
+        tracing::debug!("debug after reload");
+        tracing::trace!("trace after reload should be filtered");
+
+        // Phase 3: reload back to INFO — DEBUG events should be dropped again
+        reload_handle
+            .modify(|f| *f = EnvFilter::new("info"))
+            .unwrap();
+
+        tracing::info!("info after restore");
+        tracing::debug!("debug after restore should be filtered");
+
+        guard.shutdown().unwrap();
+
+        let logs = log_exporter.get_emitted_logs().unwrap();
+        let log_bodies: Vec<String> = logs
+            .iter()
+            .filter_map(|l| l.record.body().map(|b| format!("{b:?}")))
+            .collect();
+
+        // Phase 1 assertions
+        assert!(
+            log_bodies.iter().any(|b| b.contains("info before")),
+            "INFO event before reload should have passed, got: {log_bodies:?}"
+        );
+        assert!(
+            !log_bodies.iter().any(|b| b.contains("debug before")),
+            "DEBUG event before reload should have been filtered, got: {log_bodies:?}"
+        );
+
+        // Phase 2 assertions
+        assert!(
+            log_bodies.iter().any(|b| b.contains("info after reload")),
+            "INFO event after reload should have passed, got: {log_bodies:?}"
+        );
+        assert!(
+            log_bodies.iter().any(|b| b.contains("debug after reload")),
+            "DEBUG event after reload should have passed, got: {log_bodies:?}"
+        );
+        assert!(
+            !log_bodies.iter().any(|b| b.contains("trace after")),
+            "TRACE event after reload should have been filtered, got: {log_bodies:?}"
+        );
+
+        // Phase 3 assertions — filter restored to INFO
+        assert!(
+            log_bodies.iter().any(|b| b.contains("info after restore")),
+            "INFO event after restore should have passed, got: {log_bodies:?}"
+        );
+        assert!(
+            !log_bodies.iter().any(|b| b.contains("debug after restore")),
+            "DEBUG event after restore should have been filtered, got: {log_bodies:?}"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ use opentelemetry_sdk::{
 use regex::Regex;
 use tracing::{Level, level_filters::LevelFilter};
 
+use tracing_subscriber::layer::Filter;
+
 use crate::{ConfigureError, internal::env::get_optional_env, logfire::Logfire};
 
 /// Builder for logfire configuration, returned from [`logfire::configure()`][crate::configure].
@@ -52,6 +54,8 @@ pub struct LogfireConfigBuilder {
     // Rust specific options
     pub(crate) install_panic_handler: bool,
     pub(crate) default_level_filter: Option<LevelFilter>,
+    pub(crate) custom_tracing_filter:
+        Option<Arc<dyn Filter<tracing_subscriber::Registry> + Send + Sync + 'static>>,
 }
 
 impl Default for LogfireConfigBuilder {
@@ -70,6 +74,7 @@ impl Default for LogfireConfigBuilder {
             metrics: None,
             install_panic_handler: true,
             default_level_filter: None,
+            custom_tracing_filter: None,
         }
     }
 }
@@ -186,6 +191,38 @@ impl LogfireConfigBuilder {
     /// Set to `None` to disable metrics.
     pub fn with_metrics(mut self, metrics: Option<MetricsOptions>) -> Self {
         self.metrics = metrics;
+        self
+    }
+
+    /// Provide a custom tracing filter to use instead of the default [`EnvFilter`][tracing_subscriber::EnvFilter].
+    ///
+    /// When set, this filter replaces the default filter that Logfire constructs from
+    /// [`with_default_level_filter`][Self::with_default_level_filter] and `RUST_LOG`.
+    /// This is useful for dynamic filter reloading, e.g. via [`tracing_subscriber::reload::Layer`].
+    ///
+    /// # Example — reloadable filter
+    ///
+    /// ```rust,no_run
+    /// use tracing_subscriber::{EnvFilter, reload};
+    ///
+    /// let initial_filter = EnvFilter::builder()
+    ///     .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+    ///     .from_env_lossy();
+    /// let (filter, reload_handle) = reload::Layer::new(initial_filter);
+    ///
+    /// let logfire = logfire::configure()
+    ///     .with_tracing_filter(filter)
+    ///     .finish()
+    ///     .expect("Failed to configure logfire");
+    ///
+    /// // Later, to switch to debug:
+    /// reload_handle.modify(|f| *f = EnvFilter::new("debug")).unwrap();
+    /// ```
+    pub fn with_tracing_filter<F>(mut self, filter: F) -> Self
+    where
+        F: Filter<tracing_subscriber::Registry> + Send + Sync + 'static,
+    {
+        self.custom_tracing_filter = Some(Arc::new(filter));
         self
     }
 

--- a/src/logfire.rs
+++ b/src/logfire.rs
@@ -170,7 +170,7 @@ impl Logfire {
         LogfireTracingLayer::new(
             self.tracer.clone(),
             self.enable_tracing_metrics,
-            self.env_filter.clone(),
+            self.env_filter.clone() as _,
         )
     }
 
@@ -469,17 +469,26 @@ impl Logfire {
             filter: Arc::new(filter_builder.build()),
         };
 
-        let filter = Arc::new(
+        let env_filter = Arc::new(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(default_level_filter.into())
                 // but allow the user to override this with `RUST_LOG`
                 .from_env()?,
         );
 
+        let tracing_filter: Arc<
+            dyn tracing_subscriber::layer::Filter<tracing_subscriber::Registry>
+                + Send
+                + Sync
+                + 'static,
+        > = config
+            .custom_tracing_filter
+            .unwrap_or_else(|| env_filter.clone() as _);
+
         let subscriber = tracing_subscriber::registry().with(LogfireTracingLayer::new(
             tracer.clone(),
             advanced_options.enable_tracing_metrics,
-            filter.clone(),
+            tracing_filter,
         ));
 
         if config.install_panic_handler {
@@ -489,7 +498,7 @@ impl Logfire {
         Ok(LogfireParts {
             local: config.local,
             tracer,
-            env_filter: filter,
+            env_filter,
             subscriber: Arc::new(subscriber),
             tracer_provider,
             meter_provider,


### PR DESCRIPTION
## Summary

- Adds `LogfireConfigBuilder::with_tracing_filter()` method that accepts any `F: Filter<Registry>`, allowing consumers to replace the default `EnvFilter` with a custom filter (e.g. `reload::Layer<EnvFilter>` for dynamic reloading)
- Changes `LogfireTracingLayer::new` to accept `Arc<dyn Filter<S>>` instead of `Arc<EnvFilter>` (internal API only)
- No `local()` mode required — the custom filter integrates into the normal `finish()` flow, so the global subscriber, log bridge, console output, and meter provider all work as before

## Test plan

- [x] `test_with_tracing_filter_custom_filter` — verifies a static `LevelFilter::WARN` replaces the default, filtering out lower-level events
- [x] `test_with_tracing_filter_reload` — verifies a `reload::Layer<EnvFilter>` can dynamically switch INFO→DEBUG→INFO, with events correctly filtered at each phase
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)