### PR TITLE
update to opentelemetry 0.31

### DIFF
--- a/logfire/Cargo.toml
+++ b/logfire/Cargo.toml
@@ -17,7 +17,7 @@ env_filter = "0.1"
 
 # deps for grpc export
 http = { version = "1.2", optional = true }
-tonic = { version = "0.13", optional = true }
+tonic = { version = "0.14", optional = true }
 
 rand = "0.9.0"
 
@@ -71,8 +71,8 @@ tokio = { version = "1.44.1", features = [
 ] }
 ulid = "1.2.0"
 wiremock = "=0.6.4"
-tonic-build = "0.13"
-tonic = { version = "0.13", features = ["transport"] }
+tonic-build = "0.14"
+tonic = { version = "0.14", features = ["transport"] }
 prost = "0.14"
 opentelemetry-proto = { version = "0.31", features = [
     "tonic",

--- a/logfire/Cargo.toml
+++ b/logfire/Cargo.toml
@@ -21,11 +21,11 @@ tonic = { version = "0.13", optional = true }
 
 rand = "0.9.0"
 
-opentelemetry = { version = "0.30", default-features = false, features = [
+opentelemetry = { version = "0.31", default-features = false, features = [
     "trace",
     "logs",
 ] }
-opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
     "trace",
     "experimental_metrics_custom_reader",
     "experimental_trace_batch_span_processor_with_async_runtime",
@@ -35,7 +35,7 @@ opentelemetry_sdk = { version = "0.30", default-features = false, features = [
     "logs",
     "spec_unstable_metrics_views"
 ] }
-opentelemetry-otlp = { version = "0.30", default-features = false, features = [
+opentelemetry-otlp = { version = "0.31", default-features = false, features = [
     "trace",
     "metrics",
     "logs",
@@ -47,7 +47,7 @@ tokio = { version = "1.44.1", default-features = false, features = [
 ] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-opentelemetry = "0.31"
+tracing-opentelemetry = "0.32"
 
 thiserror.workspace = true
 
@@ -60,7 +60,7 @@ chrono = "0.4.39"
 async-trait = "0.1.88"
 futures = { version = "0.3.31", features = ["futures-executor"] }
 insta = "1.42.1"
-opentelemetry_sdk = { version = "0.30", default-features = false, features = [
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
     "testing",
 ] }
 regex = "1.11.1"
@@ -73,8 +73,8 @@ ulid = "1.2.0"
 wiremock = "=0.6.4"
 tonic-build = "0.13"
 tonic = { version = "0.13", features = ["transport"] }
-prost = "0.13"
-opentelemetry-proto = { version = "0.30", features = [
+prost = "0.14"
+opentelemetry-proto = { version = "0.31", features = [
     "tonic",
     "gen-tonic-messages",
 ] }

--- a/logfire/src/bridges/log.rs
+++ b/logfire/src/bridges/log.rs
@@ -1094,14 +1094,13 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
         let output = remap_timestamps_in_console_output(output);
 
-        assert_snapshot!(output, @r"
+        assert_snapshot!(output, @"
         1970-01-01T00:00:00.000000Z  INFO logfire::bridges::log::tests root event
         1970-01-01T00:00:00.000001Z  INFO logfire::bridges::log::tests root event with target
-        1970-01-01T00:00:00.000002Z  INFO logfire::bridges::log::tests root span
+        1970-01-01T00:00:00.000002Z  INFO root span code.file.path=logfire/src/bridges/log.rs, code.module.name=logfire::bridges::log::tests, code.line.number=1084, target=logfire::bridges::log::tests
         1970-01-01T00:00:00.000003Z  INFO logfire::bridges::log::tests hello world log
         1970-01-01T00:00:00.000004Z  WARN logfire::bridges::log::tests warning log
         1970-01-01T00:00:00.000005Z ERROR logfire::bridges::log::tests error log
-        1970-01-01T00:00:00.000006Z TRACE logfire::bridges::log::tests trace log
         ");
     }
 }

--- a/logfire/src/bridges/log.rs
+++ b/logfire/src/bridges/log.rs
@@ -1097,10 +1097,11 @@ mod tests {
         assert_snapshot!(output, @"
         1970-01-01T00:00:00.000000Z  INFO logfire::bridges::log::tests root event
         1970-01-01T00:00:00.000001Z  INFO logfire::bridges::log::tests root event with target
-        1970-01-01T00:00:00.000002Z  INFO root span code.file.path=logfire/src/bridges/log.rs, code.module.name=logfire::bridges::log::tests, code.line.number=1084, target=logfire::bridges::log::tests
+        1970-01-01T00:00:00.000002Z  INFO logfire::bridges::log::tests root span
         1970-01-01T00:00:00.000003Z  INFO logfire::bridges::log::tests hello world log
         1970-01-01T00:00:00.000004Z  WARN logfire::bridges::log::tests warning log
         1970-01-01T00:00:00.000005Z ERROR logfire::bridges::log::tests error log
+        1970-01-01T00:00:00.000006Z TRACE logfire::bridges::log::tests trace log
         ");
     }
 }

--- a/logfire/src/bridges/log.rs
+++ b/logfire/src/bridges/log.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::OnceLock};
 
 use log::{LevelFilter, Metadata, Record};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use opentelemetry::Context;
 
 use crate::internal::logfire_tracer::LogfireTracer;
 
@@ -29,7 +29,7 @@ impl log::Log for LogfireLogger {
         if self.enabled(record.metadata()) {
             self.tracer.export_log(
                 record.args().as_str(),
-                &tracing::Span::current().context(),
+                &Context::current(),
                 record.args().to_string(),
                 level_to_severity(record.level()),
                 "{}",
@@ -165,7 +165,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -177,7 +177,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         25,
@@ -187,7 +187,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -298,7 +298,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -310,7 +310,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         26,
@@ -320,7 +320,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -431,7 +431,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -443,7 +443,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         29,
@@ -453,7 +453,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -564,7 +564,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -576,7 +576,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         30,
@@ -586,7 +586,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -697,7 +697,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -709,7 +709,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         31,
@@ -719,7 +719,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -830,7 +830,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -842,7 +842,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         32,
@@ -852,7 +852,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(
@@ -963,7 +963,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Owned(
@@ -975,7 +975,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         33,
@@ -985,7 +985,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Owned(

--- a/logfire/src/bridges/tracing.rs
+++ b/logfire/src/bridges/tracing.rs
@@ -1,13 +1,7 @@
 use std::{any::TypeId, borrow::Cow, sync::Arc};
 
-use opentelemetry::{
-    Context, KeyValue,
-    global::ObjectSafeSpan,
-    logs::Severity,
-    trace::{SamplingDecision, TraceContextExt},
-};
+use opentelemetry::{Context, logs::Severity};
 use tracing::{Subscriber, field::Visit};
-use tracing_opentelemetry::{OtelData, PreSampledTracer};
 use tracing_subscriber::{EnvFilter, Layer, filter::Filtered, layer::Filter, registry::LookupSpan};
 
 use crate::{__macros_impl::LogfireValue, internal::logfire_tracer::LogfireTracer};
@@ -32,6 +26,7 @@ where
         filter: Arc<EnvFilter>,
     ) -> Self {
         let otel_layer = tracing_opentelemetry::layer()
+            .with_context_activation(true)
             .with_error_records_to_exceptions(true)
             .with_tracer(tracer.inner.clone());
 
@@ -53,7 +48,9 @@ struct LogfireTracingLayerInner<S> {
     /// This odd structure with two inner layers is deliberate; we don't want to send any events
     /// to the `otel_layer` and we only send (some) events to the `metrics_layer`.
     otel_layer: tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>,
-    metrics_layer: Option<tracing_opentelemetry::MetricsLayer<S>>,
+    metrics_layer: Option<
+        tracing_opentelemetry::MetricsLayer<S, opentelemetry_sdk::metrics::SdkMeterProvider>,
+    >,
 }
 
 impl<S> Layer<S> for LogfireTracingLayer<S>
@@ -164,50 +161,13 @@ where
     ) {
         // Delegate to OpenTelemetry layer first
         self.otel_layer.on_new_span(attrs, id, ctx.clone());
-
-        // Delegate to MetricsLayer as well
         self.metrics_layer.on_new_span(attrs, id, ctx.clone());
 
-        // Add Logfire-specific attributes
-        let span = ctx.span(id).expect("span not found");
-        let mut extensions = span.extensions_mut();
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            let attributes = otel_data
-                .builder
-                .attributes
-                .get_or_insert_with(Default::default);
-
-            attributes.push(opentelemetry::KeyValue::new(
-                "logfire.level_num",
-                tracing_level_to_severity(*attrs.metadata().level()) as i64,
-            ));
-            attributes.push(KeyValue::new("logfire.span_type", "span"));
-        }
+        self.record_logfire_attributes(attrs, id, ctx);
     }
 
-    /// Emit a pending span when this span is first entered, if this span will be sampled.
-    ///
-    /// We do this on first enter, not on creation, because some SDKs set the parent span after
-    /// creation.
-    ///
-    /// e.g. <https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/5830c9113b0d42b72167567bf8e5f4c6b20933c8/axum-tracing-opentelemetry/src/middleware/trace_extractor.rs#L132>
     fn on_enter(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
-        // Delegate to OpenTelemetry layer first
         self.otel_layer.on_enter(id, ctx.clone());
-
-        let span = ctx.span(id).expect("span not found");
-        let mut extensions = span.extensions_mut();
-
-        if extensions.get_mut::<LogfirePendingSpanSent>().is_some() {
-            return;
-        }
-
-        extensions.insert(LogfirePendingSpanSent);
-
-        // Guaranteed to be on first entering of the span
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            emit_pending_span(&self.tracer, otel_data);
-        }
     }
 
     /// Tracing events currently are recorded as span events, so do not get printed by the span emitter.
@@ -231,19 +191,7 @@ where
 
         // However we don't want to allow the opentelemetry layer to see events, it will record them
         // as span events. Instead we handle them here and emit them as log spans.
-        let event_span = ctx.event_span(event).and_then(|span| ctx.span(&span.id()));
-        let mut event_span_extensions = event_span.as_ref().map(|s| s.extensions_mut());
-
-        let context = if let Some(otel_data) = event_span_extensions
-            .as_mut()
-            .and_then(|e| e.get_mut::<OtelData>())
-        {
-            self.tracer.inner.sampled_context(otel_data)
-        } else {
-            Context::new()
-        };
-
-        emit_event_as_log_span(&self.tracer, event, &context);
+        emit_event_as_log_span(&self.tracer, event, &Context::current());
     }
 
     fn on_exit(&self, id: &tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
@@ -251,24 +199,8 @@ where
     }
 
     fn on_close(&self, id: tracing::span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
-        let span = ctx.span(&id).expect("span not found");
-        let mut extensions = span.extensions_mut();
-
-        // We write pending spans to the console; if the pending span was never created then
-        // we have to manually write it now.
-        if extensions.get_mut::<LogfirePendingSpanSent>().is_none()
-            && let Some(otel_data) = extensions.get_mut::<OtelData>()
-        {
-            // emit pending span now just before it is closed, assume the processor will
-            // deduplicate as needed
-            emit_pending_span(&self.tracer, otel_data);
-        }
-
-        // Delegate to OpenTelemetry layer after handling pending span (it will remove the
-        // `OtelData` so cannot do before).
-        drop(extensions);
-        drop(span);
-        self.otel_layer.on_close(id, ctx);
+        self.otel_layer.on_close(id.clone(), ctx.clone());
+        self.metrics_layer.on_close(id, ctx);
     }
 
     fn on_follows_from(
@@ -335,75 +267,46 @@ where
     }
 }
 
-/// Dummy struct to mark that we've already entered this span.
-struct LogfirePendingSpanSent;
+impl<S> LogfireTracingLayerInner<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    /// Creates logfire-specific attributes from the tracing metadata
+    fn record_logfire_attributes(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        static LOGFIRE_BRIDGE_CALLSITE: tracing::callsite::DefaultCallsite =
+            tracing::callsite::DefaultCallsite::new(&LOGFIRE_BRIDGE_METADATA);
 
-/// Samples and emits a pending span if the span is sampled.
-fn emit_pending_span(tracer: &LogfireTracer, otel_data: &mut tracing_opentelemetry::OtelData) {
-    let context = tracer.inner.sampled_context(otel_data);
-    let sampling_result = otel_data
-        .builder
-        .sampling_result
-        .as_ref()
-        .expect("we just asked for sampling to happen");
+        static LOGFIRE_BRIDGE_METADATA: tracing::Metadata<'static> = tracing::Metadata::new(
+            "logfire_bridge_attrs",
+            "logfire",
+            tracing::Level::TRACE,
+            None,
+            None,
+            None,
+            tracing::field::FieldSet::new(
+                &["logfire.level_num"],
+                tracing::callsite::Identifier(&LOGFIRE_BRIDGE_CALLSITE),
+            ),
+            tracing::metadata::Kind::SPAN,
+        );
 
-    // Deliberately match on all cases here so that if the enum changes in the future,
-    // we can update this code to match the possible decisions.
-    let span_is_sampled = match &sampling_result.decision {
-        SamplingDecision::Drop | SamplingDecision::RecordOnly => false,
-        SamplingDecision::RecordAndSample => true,
-    };
+        let fields = LOGFIRE_BRIDGE_METADATA.fields();
+        let level_field = fields
+            .field("logfire.level_num")
+            .expect("declared in LOGFIRE_BRIDGE_FIELDS");
 
-    if !span_is_sampled {
-        return;
+        let level_num: i64 = tracing_level_to_severity(*attrs.metadata().level()) as i64;
+
+        let values = [(&level_field, Some(&level_num as &dyn tracing::field::Value))];
+        let value_set = fields.value_set(&values);
+        self.otel_layer
+            .on_record(id, &tracing::span::Record::new(&value_set), ctx);
     }
-
-    let mut pending_span_builder = otel_data.builder.clone();
-
-    // Pending span is sent as a child of the actual span with kind pending_span.
-    // - The parent id is the actual span we want.
-    // - The pending_parent_id is the parent of the pending span.
-
-    let span_id = otel_data.builder.span_id.expect("otel SDK sets span ID");
-    pending_span_builder.span_id = Some(span_id);
-
-    let attributes = pending_span_builder
-        .attributes
-        .get_or_insert_with(Default::default);
-
-    // update type of the pending span export
-    if let Some(attr) = attributes
-        .iter_mut()
-        .find(|kv| kv.key.as_str() == "logfire.span_type")
-    {
-        attr.value = "pending_span".into();
-    } else {
-        attributes.push(opentelemetry::KeyValue::new(
-            "logfire.span_type",
-            "pending_span",
-        ));
-    }
-
-    // record the real parent ID
-    let parent_span = otel_data.parent_cx.span();
-    let parent_span_context = parent_span.span_context();
-
-    if parent_span_context.is_valid() {
-        attributes.push(opentelemetry::KeyValue::new(
-            "logfire.pending_parent_id",
-            parent_span_context.span_id().to_string(),
-        ));
-    }
-
-    pending_span_builder.span_id = Some(tracer.inner.new_span_id());
-
-    let start_time = pending_span_builder
-        .start_time
-        .expect("otel SDK sets start time");
-
-    // emit pending span
-    let mut pending_span = pending_span_builder.start_with_context(&tracer.inner, &context);
-    pending_span.end_with_timestamp(start_time);
 }
 
 pub(crate) fn tracing_level_to_severity(level: tracing::Level) -> Severity {

--- a/logfire/src/bridges/tracing.rs
+++ b/logfire/src/bridges/tracing.rs
@@ -1,8 +1,13 @@
-use std::{any::TypeId, borrow::Cow, sync::Arc};
+use std::{any::TypeId, borrow::Cow};
 
 use opentelemetry::{Context, logs::Severity};
-use tracing::{Subscriber, field::Visit};
-use tracing_subscriber::{EnvFilter, Layer, filter::Filtered, layer::Filter, registry::LookupSpan};
+use tracing::{Subscriber, field::Visit, subscriber::Interest};
+use tracing_subscriber::{
+    EnvFilter, Layer,
+    filter::{FilterExt, Filtered, combinator::And},
+    layer::Filter,
+    registry::LookupSpan,
+};
 
 use crate::{__macros_impl::LogfireValue, internal::logfire_tracer::LogfireTracer};
 
@@ -12,7 +17,10 @@ use crate::{__macros_impl::LogfireValue, internal::logfire_tracer::LogfireTracer
 /// See [`Logfire::tracing_layer`][crate::Logfire::tracing_layer] for how to use
 /// this layer.
 pub struct LogfireTracingLayer<S>(
-    Filtered<LogfireTracingLayerInner<S>, Arc<dyn Filter<S> + Send + Sync + 'static>, S>,
+    // The `Filtered` wrapper means that the context suppression and env filters are applied
+    // before entering `LogfireTracingLayerInner`, so it doesn't need to care about any
+    // filtering logic on its methods.
+    Filtered<LogfireTracingLayerInner<S>, And<ContextSuppressionFilter, EnvFilter, S>, S>,
 );
 
 impl<S> LogfireTracingLayer<S>
@@ -23,7 +31,7 @@ where
     pub(crate) fn new(
         tracer: LogfireTracer,
         enable_tracing_metrics: bool,
-        filter: Arc<EnvFilter>,
+        filter: EnvFilter,
     ) -> Self {
         let otel_layer = tracing_opentelemetry::layer()
             .with_context_activation(true)
@@ -40,7 +48,27 @@ where
             metrics_layer,
         };
 
-        Self(inner.with_filter(filter as Arc<dyn Filter<S> + Send + Sync + 'static>))
+        Self(inner.with_filter(ContextSuppressionFilter.and(filter)))
+    }
+}
+
+/// A filter that suppresses all spans and events when Otel telemetry is suppressed in the current context.
+struct ContextSuppressionFilter;
+
+impl<S> Filter<S> for ContextSuppressionFilter
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn enabled(
+        &self,
+        _metadata: &tracing::Metadata<'_>,
+        _ctx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        !Context::is_current_telemetry_suppressed()
+    }
+
+    fn callsite_enabled(&self, _meta: &'static tracing::Metadata<'static>) -> Interest {
+        Interest::sometimes()
     }
 }
 
@@ -66,10 +94,7 @@ where
         self.0.on_layer(subscriber);
     }
 
-    fn register_callsite(
-        &self,
-        metadata: &'static tracing::Metadata<'static>,
-    ) -> tracing::subscriber::Interest {
+    fn register_callsite(&self, metadata: &'static tracing::Metadata<'static>) -> Interest {
         self.0.register_callsite(metadata)
     }
 
@@ -524,7 +549,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            464,
+                            33,
                         ),
                     },
                     KeyValue {
@@ -631,7 +656,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            465,
+                            34,
                         ),
                     },
                     KeyValue {
@@ -748,7 +773,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            465,
+                            34,
                         ),
                     },
                     KeyValue {
@@ -861,7 +886,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            466,
+                            35,
                         ),
                     },
                     KeyValue {
@@ -978,7 +1003,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            466,
+                            35,
                         ),
                     },
                     KeyValue {
@@ -1091,7 +1116,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            467,
+                            36,
                         ),
                     },
                     KeyValue {
@@ -1208,7 +1233,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            467,
+                            36,
                         ),
                     },
                     KeyValue {
@@ -1321,7 +1346,7 @@ mod tests {
                             "code.line.number",
                         ),
                         value: I64(
-                            464,
+                            33,
                         ),
                     },
                     KeyValue {
@@ -1436,7 +1461,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Static(
@@ -1448,7 +1473,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         30,
@@ -1458,7 +1483,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Static(
@@ -1569,7 +1594,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Static(
@@ -1581,7 +1606,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         31,
@@ -1591,7 +1616,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Static(
@@ -1712,7 +1737,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Static(
@@ -1724,7 +1749,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         38,
@@ -1734,7 +1759,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Static(
@@ -1845,7 +1870,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.filepath",
+                                        "code.file.path",
                                     ),
                                     String(
                                         Static(
@@ -1857,7 +1882,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.lineno",
+                                        "code.line.number",
                                     ),
                                     Int(
                                         39,
@@ -1867,7 +1892,7 @@ mod tests {
                             Some(
                                 (
                                     Static(
-                                        "code.namespace",
+                                        "code.module.name",
                                     ),
                                     String(
                                         Static(

--- a/logfire/src/bridges/tracing.rs
+++ b/logfire/src/bridges/tracing.rs
@@ -27,6 +27,7 @@ where
     ) -> Self {
         let otel_layer = tracing_opentelemetry::layer()
             .with_context_activation(true)
+            .with_target(false)
             .with_error_records_to_exceptions(true)
             .with_tracer(tracer.inner.clone());
 
@@ -415,7 +416,8 @@ mod tests {
     use tracing::{Level, level_filters::LevelFilter};
 
     use crate::{
-        config::{AdvancedOptions, ConsoleOptions, Target},
+        config::{AdvancedOptions, ConsoleOptions, SharedIdGenerator, Target},
+        internal::pending_span_processor::PendingSpanProcessor,
         set_local_logfire,
         test_utils::{
             DeterministicExporter, DeterministicIdGenerator, make_deterministic_logs,
@@ -431,21 +433,27 @@ mod tests {
         let exporter = InMemorySpanExporterBuilder::new().build();
         let log_exporter = InMemoryLogExporter::default();
 
-        let logfire =
-            crate::configure()
-                .local()
-                .send_to_logfire(false)
-                .with_additional_span_processor(SimpleSpanProcessor::new(
-                    DeterministicExporter::new(exporter.clone(), TEST_FILE, TEST_LINE),
-                ))
-                .with_default_level_filter(LevelFilter::TRACE)
-                .with_advanced_options(
-                    AdvancedOptions::default()
-                        .with_id_generator(DeterministicIdGenerator::new())
-                        .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
-                )
-                .finish()
-                .unwrap();
+        let id_generator = SharedIdGenerator::new(Arc::new(DeterministicIdGenerator::new()));
+
+        let logfire = crate::configure()
+            .local()
+            .send_to_logfire(false)
+            .with_additional_span_processor(PendingSpanProcessor::new(
+                SimpleSpanProcessor::new(DeterministicExporter::new(
+                    exporter.clone(),
+                    TEST_FILE,
+                    TEST_LINE,
+                )),
+                id_generator.clone(),
+            ))
+            .with_default_level_filter(LevelFilter::TRACE)
+            .with_advanced_options(
+                AdvancedOptions::default()
+                    .with_id_generator(id_generator)
+                    .with_log_processor(SimpleLogProcessor::new(log_exporter.clone())),
+            )
+            .finish()
+            .unwrap();
 
         let guard = set_local_logfire(logfire);
 
@@ -479,6 +487,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "root span",
                 start_time: SystemTime {
@@ -492,7 +501,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -502,7 +511,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -512,10 +521,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            27,
+                            464,
                         ),
                     },
                     KeyValue {
@@ -585,6 +594,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f2,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "hello world span",
                 start_time: SystemTime {
@@ -598,7 +608,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -608,7 +618,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -618,10 +628,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            28,
+                            465,
                         ),
                     },
                     KeyValue {
@@ -701,6 +711,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "hello world span",
                 start_time: SystemTime {
@@ -714,7 +725,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -724,7 +735,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -734,10 +745,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            28,
+                            465,
                         ),
                     },
                     KeyValue {
@@ -764,16 +775,6 @@ mod tests {
                         ),
                         value: I64(
                             9,
-                        ),
-                    },
-                    KeyValue {
-                        key: Static(
-                            "logfire.span_type",
-                        ),
-                        value: String(
-                            Static(
-                                "span",
-                            ),
                         ),
                     },
                     KeyValue {
@@ -823,6 +824,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f4,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span",
                 start_time: SystemTime {
@@ -836,7 +838,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -846,7 +848,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -856,10 +858,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            29,
+                            466,
                         ),
                     },
                     KeyValue {
@@ -939,6 +941,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span",
                 start_time: SystemTime {
@@ -952,7 +955,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -962,7 +965,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -972,10 +975,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            29,
+                            466,
                         ),
                     },
                     KeyValue {
@@ -1002,16 +1005,6 @@ mod tests {
                         ),
                         value: I64(
                             5,
-                        ),
-                    },
-                    KeyValue {
-                        key: Static(
-                            "logfire.span_type",
-                        ),
-                        value: String(
-                            Static(
-                                "span",
-                            ),
                         ),
                     },
                     KeyValue {
@@ -1061,6 +1054,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f6,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span with explicit parent",
                 start_time: SystemTime {
@@ -1074,7 +1068,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -1084,7 +1078,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -1094,10 +1088,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            30,
+                            467,
                         ),
                     },
                     KeyValue {
@@ -1177,6 +1171,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 00000000000000f0,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "debug span with explicit parent",
                 start_time: SystemTime {
@@ -1190,7 +1185,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -1200,7 +1195,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -1210,10 +1205,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            30,
+                            467,
                         ),
                     },
                     KeyValue {
@@ -1240,16 +1235,6 @@ mod tests {
                         ),
                         value: I64(
                             5,
-                        ),
-                    },
-                    KeyValue {
-                        key: Static(
-                            "logfire.span_type",
-                        ),
-                        value: String(
-                            Static(
-                                "span",
-                            ),
                         ),
                     },
                     KeyValue {
@@ -1299,6 +1284,7 @@ mod tests {
                     ),
                 },
                 parent_span_id: 0000000000000000,
+                parent_span_is_remote: false,
                 span_kind: Internal,
                 name: "root span",
                 start_time: SystemTime {
@@ -1312,7 +1298,7 @@ mod tests {
                 attributes: [
                     KeyValue {
                         key: Static(
-                            "code.filepath",
+                            "code.file.path",
                         ),
                         value: String(
                             Static(
@@ -1322,7 +1308,7 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.namespace",
+                            "code.module.name",
                         ),
                         value: String(
                             Static(
@@ -1332,10 +1318,10 @@ mod tests {
                     },
                     KeyValue {
                         key: Static(
-                            "code.lineno",
+                            "code.line.number",
                         ),
                         value: I64(
-                            27,
+                            464,
                         ),
                     },
                     KeyValue {
@@ -1362,16 +1348,6 @@ mod tests {
                         ),
                         value: I64(
                             9,
-                        ),
-                    },
-                    KeyValue {
-                        key: Static(
-                            "logfire.span_type",
-                        ),
-                        value: String(
-                            Static(
-                                "span",
-                            ),
                         ),
                     },
                     KeyValue {
@@ -1475,7 +1451,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        24,
+                                        30,
                                     ),
                                 ),
                             ),
@@ -1608,7 +1584,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        25,
+                                        31,
                                     ),
                                 ),
                             ),
@@ -1751,7 +1727,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        32,
+                                        38,
                                     ),
                                 ),
                             ),
@@ -1884,7 +1860,7 @@ mod tests {
                                         "code.lineno",
                                     ),
                                     Int(
-                                        33,
+                                        39,
                                     ),
                                 ),
                             ),
@@ -2274,7 +2250,7 @@ mod tests {
                         scope: InstrumentationScope {
                             name: "tracing/tracing-opentelemetry",
                             version: Some(
-                                "0.31.0",
+                                "0.32.1",
                             ),
                             schema_url: None,
                             attributes: [],
@@ -2350,7 +2326,7 @@ mod tests {
                         scope: InstrumentationScope {
                             name: "tracing/tracing-opentelemetry",
                             version: Some(
-                                "0.31.0",
+                                "0.32.1",
                             ),
                             schema_url: None,
                             attributes: [],

--- a/logfire/src/config.rs
+++ b/logfire/src/config.rs
@@ -389,7 +389,7 @@ impl std::fmt::Debug for Target {
 #[derive(Default)]
 pub struct AdvancedOptions {
     pub(crate) base_url: Option<String>,
-    pub(crate) id_generator: Option<BoxedIdGenerator>,
+    pub(crate) id_generator: Option<SharedIdGenerator>,
     pub(crate) resources: Vec<opentelemetry_sdk::Resource>,
     pub(crate) log_record_processors: Vec<BoxedLogProcessor>,
     pub(crate) enable_tracing_metrics: bool,
@@ -415,7 +415,7 @@ impl AdvancedOptions {
         mut self,
         generator: T,
     ) -> Self {
-        self.id_generator = Some(BoxedIdGenerator::new(Box::new(generator)));
+        self.id_generator = Some(SharedIdGenerator::new(Arc::new(generator)));
         self
     }
 
@@ -505,16 +505,16 @@ impl SpanProcessor for BoxedSpanProcessor {
 }
 
 /// Wrapper around an `IdGenerator` to use in `id_generator`.
-#[derive(Debug)]
-pub(crate) struct BoxedIdGenerator(Box<dyn IdGenerator>);
+#[derive(Debug, Clone)]
+pub(crate) struct SharedIdGenerator(Arc<dyn IdGenerator>);
 
-impl BoxedIdGenerator {
-    pub fn new(generator: Box<dyn IdGenerator>) -> Self {
-        BoxedIdGenerator(generator)
+impl SharedIdGenerator {
+    pub fn new(generator: Arc<dyn IdGenerator>) -> Self {
+        SharedIdGenerator(generator)
     }
 }
 
-impl IdGenerator for BoxedIdGenerator {
+impl IdGenerator for SharedIdGenerator {
     fn new_trace_id(&self) -> opentelemetry::trace::TraceId {
         self.0.new_trace_id()
     }

--- a/logfire/src/internal/exporters/console.rs
+++ b/logfire/src/internal/exporters/console.rs
@@ -305,13 +305,13 @@ impl ConsoleWriter {
                         level = Some(level_num);
                     }
                 }
-                "code.namespace" => target = Some(kv.value.as_str()),
+                "code.module.name" => target = Some(kv.value.as_str()),
                 // Filter out known values
                 ATTRIBUTES_SPAN_TYPE_KEY
                 | "logfire.json_schema"
                 | "logfire.pending_parent_id"
-                | "code.filepath"
-                | "code.lineno"
+                | "code.file.path"
+                | "code.line.number"
                 | "thread.id"
                 | "thread.name"
                 | "logfire.null_args"
@@ -548,10 +548,10 @@ mod tests {
         let output = remap_timestamps_in_console_output(output);
 
         assert_snapshot!(output, @"
-        1970-01-01T00:00:00.000000Z  INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=533, target=logfire::internal::exporters::console::tests
-        1970-01-01T00:00:00.000001Z  INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=534, target=logfire::internal::exporters::console::tests
-        1970-01-01T00:00:00.000002Z DEBUG debug span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=535, target=logfire::internal::exporters::console::tests
-        1970-01-01T00:00:00.000003Z DEBUG debug span with explicit parent code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=537, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000000Z  INFO logfire::internal::exporters::console::tests root span
+        1970-01-01T00:00:00.000001Z  INFO logfire::internal::exporters::console::tests hello world span
+        1970-01-01T00:00:00.000002Z DEBUG logfire::internal::exporters::console::tests debug span
+        1970-01-01T00:00:00.000003Z DEBUG logfire::internal::exporters::console::tests debug span with explicit parent
         1970-01-01T00:00:00.000004Z  INFO logfire::internal::exporters::console::tests log with values foo=42, bar=33
         1970-01-01T00:00:00.000005Z  INFO logfire::internal::exporters::console::tests hello world log
         1970-01-01T00:00:00.000006Z ERROR panic: oh no! backtrace=disabled backtrace
@@ -596,10 +596,10 @@ mod tests {
         let output = remap_timestamps_in_console_output(output);
 
         assert_snapshot!(output, @"
-        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [1mroot span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=581, [3mtarget[0m=logfire::internal::exporters::console::tests
-        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [1mhello world span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=582, [3mtarget[0m=logfire::internal::exporters::console::tests
-        [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [1mdebug span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=583, [3mtarget[0m=logfire::internal::exporters::console::tests
-        [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [1mdebug span with explicit parent[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=585, [3mtarget[0m=logfire::internal::exporters::console::tests
+        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mroot span[0m
+        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world span[0m
+        [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
+        [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
         [2m1970-01-01T00:00:00.000004Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mlog with values[0m [3mfoo[0m=42, [3mbar[0m=33
         [2m1970-01-01T00:00:00.000005Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
         [2m1970-01-01T00:00:00.000006Z[0m[31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
@@ -643,10 +643,10 @@ mod tests {
         let output = remap_timestamps_in_console_output(output);
 
         assert_snapshot!(output, @"
-         INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=629, target=logfire::internal::exporters::console::tests
-         INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=630, target=logfire::internal::exporters::console::tests
-        DEBUG debug span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=631, target=logfire::internal::exporters::console::tests
-        DEBUG debug span with explicit parent code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=633, target=logfire::internal::exporters::console::tests
+         INFO logfire::internal::exporters::console::tests root span
+         INFO logfire::internal::exporters::console::tests hello world span
+        DEBUG logfire::internal::exporters::console::tests debug span
+        DEBUG logfire::internal::exporters::console::tests debug span with explicit parent
          INFO logfire::internal::exporters::console::tests hello world log
         ERROR panic: oh no! backtrace=disabled backtrace
         ");
@@ -688,8 +688,8 @@ mod tests {
         let output = remap_timestamps_in_console_output(output);
 
         assert_snapshot!(output, @"
-        1970-01-01T00:00:00.000000Z  INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=674, target=logfire::internal::exporters::console::tests
-        1970-01-01T00:00:00.000001Z  INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=675, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000000Z  INFO logfire::internal::exporters::console::tests root span
+        1970-01-01T00:00:00.000001Z  INFO logfire::internal::exporters::console::tests hello world span
         1970-01-01T00:00:00.000002Z  INFO logfire::internal::exporters::console::tests hello world log
         1970-01-01T00:00:00.000003Z ERROR panic: oh no! backtrace=disabled backtrace
         ");

--- a/logfire/src/internal/exporters/console.rs
+++ b/logfire/src/internal/exporters/console.rs
@@ -378,15 +378,15 @@ impl ConsoleWriter {
                         msg = Some(s.as_str());
                     }
                 }
-                "code.namespace" => {
+                "code.module.name" => {
                     if let opentelemetry::logs::AnyValue::String(s) = value {
                         target = Some(s.as_str());
                     }
                 }
                 // Filter out known values
                 "logfire.json_schema"
-                | "code.filepath"
-                | "code.lineno"
+                | "code.file.path"
+                | "code.line.number"
                 | "thread.id"
                 | "thread.name"
                 | "logfire.null_args"

--- a/logfire/src/internal/exporters/console.rs
+++ b/logfire/src/internal/exporters/console.rs
@@ -547,11 +547,11 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
         let output = remap_timestamps_in_console_output(output);
 
-        assert_snapshot!(output, @r"
-        1970-01-01T00:00:00.000000Z  INFO logfire::internal::exporters::console::tests root span
-        1970-01-01T00:00:00.000001Z  INFO logfire::internal::exporters::console::tests hello world span
-        1970-01-01T00:00:00.000002Z DEBUG logfire::internal::exporters::console::tests debug span
-        1970-01-01T00:00:00.000003Z DEBUG logfire::internal::exporters::console::tests debug span with explicit parent
+        assert_snapshot!(output, @"
+        1970-01-01T00:00:00.000000Z  INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=533, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000001Z  INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=534, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000002Z DEBUG debug span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=535, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000003Z DEBUG debug span with explicit parent code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=537, target=logfire::internal::exporters::console::tests
         1970-01-01T00:00:00.000004Z  INFO logfire::internal::exporters::console::tests log with values foo=42, bar=33
         1970-01-01T00:00:00.000005Z  INFO logfire::internal::exporters::console::tests hello world log
         1970-01-01T00:00:00.000006Z ERROR panic: oh no! backtrace=disabled backtrace
@@ -595,11 +595,11 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
         let output = remap_timestamps_in_console_output(output);
 
-        assert_snapshot!(output, @r"
-        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mroot span[0m
-        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world span[0m
-        [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span[0m
-        [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mdebug span with explicit parent[0m
+        assert_snapshot!(output, @"
+        [2m1970-01-01T00:00:00.000000Z[0m[32m  INFO[0m [1mroot span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=581, [3mtarget[0m=logfire::internal::exporters::console::tests
+        [2m1970-01-01T00:00:00.000001Z[0m[32m  INFO[0m [1mhello world span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=582, [3mtarget[0m=logfire::internal::exporters::console::tests
+        [2m1970-01-01T00:00:00.000002Z[0m[34m DEBUG[0m [1mdebug span[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=583, [3mtarget[0m=logfire::internal::exporters::console::tests
+        [2m1970-01-01T00:00:00.000003Z[0m[34m DEBUG[0m [1mdebug span with explicit parent[0m [3mcode.file.path[0m=logfire/src/internal/exporters/console.rs, [3mcode.module.name[0m=logfire::internal::exporters::console::tests, [3mcode.line.number[0m=585, [3mtarget[0m=logfire::internal::exporters::console::tests
         [2m1970-01-01T00:00:00.000004Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mlog with values[0m [3mfoo[0m=42, [3mbar[0m=33
         [2m1970-01-01T00:00:00.000005Z[0m[32m  INFO[0m [2;3mlogfire::internal::exporters::console::tests[0m [1mhello world log[0m
         [2m1970-01-01T00:00:00.000006Z[0m[31m ERROR[0m [1mpanic: oh no![0m [3mbacktrace[0m=disabled backtrace
@@ -642,11 +642,11 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
         let output = remap_timestamps_in_console_output(output);
 
-        assert_snapshot!(output, @r"
-         INFO logfire::internal::exporters::console::tests root span
-         INFO logfire::internal::exporters::console::tests hello world span
-        DEBUG logfire::internal::exporters::console::tests debug span
-        DEBUG logfire::internal::exporters::console::tests debug span with explicit parent
+        assert_snapshot!(output, @"
+         INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=629, target=logfire::internal::exporters::console::tests
+         INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=630, target=logfire::internal::exporters::console::tests
+        DEBUG debug span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=631, target=logfire::internal::exporters::console::tests
+        DEBUG debug span with explicit parent code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=633, target=logfire::internal::exporters::console::tests
          INFO logfire::internal::exporters::console::tests hello world log
         ERROR panic: oh no! backtrace=disabled backtrace
         ");
@@ -687,9 +687,9 @@ mod tests {
         let output = std::str::from_utf8(&output).unwrap();
         let output = remap_timestamps_in_console_output(output);
 
-        assert_snapshot!(output, @r"
-        1970-01-01T00:00:00.000000Z  INFO logfire::internal::exporters::console::tests root span
-        1970-01-01T00:00:00.000001Z  INFO logfire::internal::exporters::console::tests hello world span
+        assert_snapshot!(output, @"
+        1970-01-01T00:00:00.000000Z  INFO root span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=674, target=logfire::internal::exporters::console::tests
+        1970-01-01T00:00:00.000001Z  INFO hello world span code.file.path=logfire/src/internal/exporters/console.rs, code.module.name=logfire::internal::exporters::console::tests, code.line.number=675, target=logfire::internal::exporters::console::tests
         1970-01-01T00:00:00.000002Z  INFO logfire::internal::exporters::console::tests hello world log
         1970-01-01T00:00:00.000003Z ERROR panic: oh no! backtrace=disabled backtrace
         ");

--- a/logfire/src/internal/exporters/remove_pending.rs
+++ b/logfire/src/internal/exporters/remove_pending.rs
@@ -118,15 +118,15 @@ mod tests {
         spans.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         let spans = spans
             .iter()
-            .map(|span| (span.name.as_ref(), span.get_span_type()))
+            .map(|span| (span.name.as_ref(), span.get_span_type().unwrap_or("span")))
             .collect::<Vec<_>>();
 
         assert_eq!(
             spans,
             vec![
-                ("debug span", Some("span")),
-                ("hello world span", Some("span")),
-                ("root span", Some("span")),
+                ("debug span", "span"),
+                ("hello world span", "span"),
+                ("root span", "span"),
             ]
         );
     }

--- a/logfire/src/internal/exporters/remove_pending.rs
+++ b/logfire/src/internal/exporters/remove_pending.rs
@@ -41,17 +41,19 @@ impl<Inner: SpanExporter> SpanExporter for RemovePendingSpansExporter<Inner> {
                         spans_by_id.entry(key).or_insert(span);
                         None
                     }
-                    Some("span") => {
+                    // None should be treated as equivalent to "span" (is more efficient to omit the attribute)
+                    Some("span") | None => {
                         let key = (span.span_context.trace_id(), span.span_context.span_id());
                         spans_by_id.insert(key, span);
                         None
                     }
-                    _ => Some(span),
+                    Some(_) => Some(span),
                 }
             })
             .collect();
 
         spans.extend(spans_by_id.into_values());
+
         self.0.export(spans).await
     }
 

--- a/logfire/src/internal/logfire_tracer.rs
+++ b/logfire/src/internal/logfire_tracer.rs
@@ -139,15 +139,15 @@ impl LogfireTracer {
         }
 
         if let Some(file) = file {
-            log_record.add_attribute("code.filepath", file);
+            log_record.add_attribute("code.file.path", file);
         }
 
         if let Some(line) = line {
-            log_record.add_attribute("code.lineno", i64::from(line));
+            log_record.add_attribute("code.line.number", i64::from(line));
         }
 
         if let Some(module_path) = module_path {
-            log_record.add_attribute("code.namespace", module_path);
+            log_record.add_attribute("code.module.name", module_path);
         }
 
         if !null_args.is_empty() {

--- a/logfire/src/internal/mod.rs
+++ b/logfire/src/internal/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod env;
 pub(crate) mod exporters;
 pub(crate) mod log_processor_shutdown_hack;
 pub(crate) mod logfire_tracer;
+pub(crate) mod pending_span_processor;
 pub(crate) mod span_data_ext;

--- a/logfire/src/internal/pending_span_processor.rs
+++ b/logfire/src/internal/pending_span_processor.rs
@@ -1,0 +1,93 @@
+use opentelemetry::{KeyValue, SpanId, trace::SpanContext};
+use opentelemetry_sdk::trace::{IdGenerator, SpanData, SpanProcessor};
+
+use crate::{config::SharedIdGenerator, internal::span_data_ext::SpanDataExt};
+
+/// Wrapper around a `SpanProcessor` which emits pending logfire spans on `on_start`.
+#[derive(Debug)]
+pub(crate) struct PendingSpanProcessor<T> {
+    id_generator: SharedIdGenerator,
+    inner: T,
+}
+
+impl<T> PendingSpanProcessor<T> {
+    pub fn new(inner: T, id_generator: SharedIdGenerator) -> Self {
+        Self {
+            inner,
+            id_generator,
+        }
+    }
+}
+
+impl<T: SpanProcessor> SpanProcessor for PendingSpanProcessor<T> {
+    fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, cx: &opentelemetry::Context) {
+        self.inner.on_start(span, cx);
+
+        let Some(data) = span.exported_data() else {
+            return;
+        };
+
+        // Only "real" spans should have pending spans emitted. `None` is handled transparently
+        // in the backend a "real" span. (This avoids "log" type in particular).
+        if data.get_span_type().is_some_and(|s| s != "span") {
+            return;
+        }
+
+        let mut attributes = data.attributes;
+        if let Some(attr) = attributes
+            .iter_mut()
+            .find(|kv| kv.key.as_str() == "logfire.span_type")
+        {
+            attr.value = "pending_span".into();
+        } else {
+            attributes.push(KeyValue::new("logfire.span_type", "pending_span"));
+        }
+        if data.parent_span_id != SpanId::INVALID {
+            attributes.push(KeyValue::new(
+                "logfire.pending_parent_id",
+                data.parent_span_id.to_string(),
+            ));
+        }
+
+        let pending = SpanData {
+            span_context: SpanContext::new(
+                data.span_context.trace_id(),
+                self.id_generator.new_span_id(),
+                data.span_context.trace_flags(),
+                false,
+                data.span_context.trace_state().clone(),
+            ),
+            // The pending span is exported as a child of the real span, so the real span's
+            // span_id becomes the pending span's parent.
+            parent_span_id: data.span_context.span_id(),
+            parent_span_is_remote: false,
+            span_kind: data.span_kind,
+            name: data.name,
+            start_time: data.start_time,
+            end_time: data.start_time,
+            attributes,
+            dropped_attributes_count: data.dropped_attributes_count,
+            events: data.events,
+            links: data.links,
+            status: data.status,
+            instrumentation_scope: data.instrumentation_scope,
+        };
+
+        self.inner.on_end(pending);
+    }
+
+    fn on_end(&self, span: opentelemetry_sdk::trace::SpanData) {
+        self.inner.on_end(span);
+    }
+
+    fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+}

--- a/logfire/src/internal/pending_span_processor.rs
+++ b/logfire/src/internal/pending_span_processor.rs
@@ -27,9 +27,14 @@ impl<T: SpanProcessor> SpanProcessor for PendingSpanProcessor<T> {
             return;
         };
 
-        // Only "real" spans should have pending spans emitted. `None` is handled transparently
-        // in the backend a "real" span. (This avoids "log" type in particular).
-        if data.get_span_type().is_some_and(|s| s != "span") {
+        // Only "real" spans should have pending spans emitted.
+        // None is treated as equivalent to "span" (is more efficient to omit the attribute).
+        //
+        // In particular "log" type might exist here and we don't want to emit pending spans for logs.
+        //
+        // TODO: it would be nice if this check could be done before the call to `exported_data()`,
+        // but that requires the otel SDK to support reading span attributes from `Span`.
+        if data.get_span_type().unwrap_or("span") != "span" {
             return;
         }
 

--- a/logfire/src/internal/pending_span_processor.rs
+++ b/logfire/src/internal/pending_span_processor.rs
@@ -6,8 +6,8 @@ use crate::{config::SharedIdGenerator, internal::span_data_ext::SpanDataExt};
 /// Wrapper around a `SpanProcessor` which emits pending logfire spans on `on_start`.
 #[derive(Debug)]
 pub(crate) struct PendingSpanProcessor<T> {
-    id_generator: SharedIdGenerator,
     inner: T,
+    id_generator: SharedIdGenerator,
 }
 
 impl<T> PendingSpanProcessor<T> {
@@ -95,7 +95,7 @@ impl<T: SpanProcessor> SpanProcessor for PendingSpanProcessor<T> {
         self.inner.shutdown()
     }
 
-    fn set_resource(&mut self, _resource: &opentelemetry_sdk::Resource) {
-        self.inner.set_resource(_resource);
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
     }
 }

--- a/logfire/src/internal/pending_span_processor.rs
+++ b/logfire/src/internal/pending_span_processor.rs
@@ -90,4 +90,12 @@ impl<T: SpanProcessor> SpanProcessor for PendingSpanProcessor<T> {
     ) -> opentelemetry_sdk::error::OTelSdkResult {
         self.inner.shutdown_with_timeout(timeout)
     }
+
+    fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.shutdown()
+    }
+
+    fn set_resource(&mut self, _resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(_resource);
+    }
 }

--- a/logfire/src/logfire.rs
+++ b/logfire/src/logfire.rs
@@ -40,13 +40,14 @@ use crate::{
     bridges::tracing::LogfireTracingLayer,
     config::{
         LOGFIRE_BASE_URL, LOGFIRE_ENVIRONMENT, LOGFIRE_SEND_TO_LOGFIRE, LOGFIRE_SERVICE_NAME,
-        LOGFIRE_SERVICE_VERSION, LOGFIRE_TOKEN_VALUE, SendToLogfire,
+        LOGFIRE_SERVICE_VERSION, LOGFIRE_TOKEN_VALUE, SendToLogfire, SharedIdGenerator,
     },
     internal::{
         env::get_optional_env,
         exporters::console::{ConsoleWriter, create_console_processors},
         log_processor_shutdown_hack::LogProcessorShutdownHack,
         logfire_tracer::{GLOBAL_TRACER, LOCAL_TRACER, LogfireTracer},
+        pending_span_processor::PendingSpanProcessor,
     },
     metrics,
     ulid_id_generator::UlidIdGenerator,
@@ -317,13 +318,6 @@ impl Logfire {
         let mut logger_provider_builder = SdkLoggerProvider::builder();
         let mut meter_provider_builder = SdkMeterProvider::builder();
 
-        if let Some(id_generator) = advanced_options.id_generator {
-            tracer_provider_builder = tracer_provider_builder.with_id_generator(id_generator);
-        } else {
-            tracer_provider_builder =
-                tracer_provider_builder.with_id_generator(UlidIdGenerator::new());
-        }
-
         // Add service-specific resources from config
         let mut service_resource_builder = opentelemetry_sdk::Resource::builder();
 
@@ -376,6 +370,11 @@ impl Logfire {
             None
         };
 
+        let id_generator = advanced_options
+            .id_generator
+            .clone()
+            .unwrap_or_else(|| SharedIdGenerator::new(Arc::new(UlidIdGenerator::new())));
+
         let shutdown_sender = if let Some(ref logfire_base_url) = logfire_base_url {
             let (shutdown_tx, span_processor, log_processor, metrics_processor) =
                 spawn_runtime_and_exporters(
@@ -384,7 +383,9 @@ impl Logfire {
                     config.metrics.is_some(),
                 )?;
 
-            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+            tracer_provider_builder = tracer_provider_builder.with_span_processor(
+                PendingSpanProcessor::new(span_processor, id_generator.clone()),
+            );
             logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
             if let Some(metrics_processor) = metrics_processor {
                 meter_provider_builder = meter_provider_builder.with_reader(metrics_processor);
@@ -400,13 +401,17 @@ impl Logfire {
             .map(|o| create_console_processors(Arc::new(ConsoleWriter::new(o))));
 
         if let Some((span_processor, log_processor)) = console_processors {
-            tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
+            tracer_provider_builder = tracer_provider_builder.with_span_processor(
+                PendingSpanProcessor::new(span_processor, id_generator.clone()),
+            );
             logger_provider_builder = logger_provider_builder.with_log_processor(log_processor);
         }
 
         for span_processor in config.additional_span_processors {
             tracer_provider_builder = tracer_provider_builder.with_span_processor(span_processor);
         }
+
+        tracer_provider_builder = tracer_provider_builder.with_id_generator(id_generator);
 
         let tracer_provider = tracer_provider_builder.build();
         let tracer = tracer_provider.tracer("logfire");

--- a/logfire/src/logfire.rs
+++ b/logfire/src/logfire.rs
@@ -15,7 +15,7 @@ use logfire_core::Region;
 
 use opentelemetry::{
     Context,
-    logs::{LoggerProvider as _, Severity},
+    logs::{LoggerProvider, Severity},
     metrics::MeterProvider,
     trace::TracerProvider,
 };
@@ -32,7 +32,6 @@ use opentelemetry_sdk::{
     },
 };
 use tracing::{Subscriber, level_filters::LevelFilter, subscriber::DefaultGuard};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, registry::LookupSpan};
 
 #[cfg(feature = "data-dir")]
@@ -63,7 +62,7 @@ use crate::{
 pub struct Logfire {
     pub(crate) tracer_provider: SdkTracerProvider,
     pub(crate) tracer: LogfireTracer,
-    pub(crate) env_filter: Arc<EnvFilter>,
+    pub(crate) env_filter: EnvFilter,
     pub(crate) subscriber: Arc<dyn Subscriber + Send + Sync>,
     pub(crate) meter_provider: SdkMeterProvider,
     pub(crate) logger_provider: SdkLoggerProvider,
@@ -494,12 +493,10 @@ impl Logfire {
             filter: Arc::new(filter_builder.build()),
         };
 
-        let filter = Arc::new(
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(default_level_filter.into())
-                // but allow the user to override this with `RUST_LOG`
-                .from_env()?,
-        );
+        let filter = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(default_level_filter.into())
+            // but allow the user to override this with `RUST_LOG`
+            .from_env()?;
 
         let subscriber = tracing_subscriber::registry().with(LogfireTracingLayer::new(
             tracer.clone(),
@@ -578,7 +575,7 @@ impl Drop for ShutdownGuard {
 struct LogfireParts {
     local: bool,
     tracer: LogfireTracer,
-    env_filter: Arc<EnvFilter>,
+    env_filter: EnvFilter,
     subscriber: Arc<dyn Subscriber + Send + Sync>,
     tracer_provider: SdkTracerProvider,
     meter_provider: SdkMeterProvider,
@@ -616,7 +613,7 @@ fn install_panic_handler() {
             let location = info.location();
             tracer.export_log(
                 None,
-                &tracing::Span::current().context(),
+                &Context::current(),
                 format!("panic: {message}"),
                 Severity::Error,
                 crate::__json_schema!(backtrace),
@@ -770,8 +767,11 @@ fn spawn_runtime_and_exporters(
 
     let (span_processor, log_processor, metrics_processor) = std::thread::scope(|s| {
         s.spawn(|| -> Result<_, ConfigureError> {
+            // avoid telemetry logs being generated from exporter setup (or spans they create)
+            let _ctx_guard = Context::enter_telemetry_suppressed_scope();
+
             // all these processors spawn tasks on the runtime when they are created.
-            let _guard = handle.enter();
+            let _rt_guard = handle.enter();
 
             let span_processor = BatchSpanProcessor::builder(
                 crate::exporters::span_exporter(logfire_base_url, http_headers.clone())?,

--- a/logfire/src/macros/impl_.rs
+++ b/logfire/src/macros/impl_.rs
@@ -9,7 +9,7 @@ use crate::{
     bridges::tracing::{tracing_level_to_log_level, tracing_level_to_severity},
     internal::logfire_tracer::LogfireTracer,
 };
-use opentelemetry::{Key, Value};
+use opentelemetry::{Context, Key, Value};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 // Re-export macros marked with `#[macro_export]` from this module, because `#[macro_export]` places
@@ -210,6 +210,11 @@ impl<T> ConvertValue<T> {
 
 #[must_use]
 pub fn enabled(level: tracing::Level, module_path: &'static str) -> bool {
+    // Don't bother doing any log processing is telemetry is suppressed
+    if Context::is_current_telemetry_suppressed() {
+        return false;
+    }
+
     LogfireTracer::try_with(|tracer| {
         tracer.enabled(
             &log::Metadata::builder()

--- a/logfire/src/test_utils.rs
+++ b/logfire/src/test_utils.rs
@@ -35,11 +35,16 @@ pub struct DeterministicIdGenerator {
 
 impl IdGenerator for DeterministicIdGenerator {
     fn new_trace_id(&self) -> opentelemetry::trace::TraceId {
-        TraceId::from_u128(self.next_trace_id.fetch_add(1, Ordering::Relaxed).into())
+        let trace_id: u128 = self.next_trace_id.fetch_add(1, Ordering::Relaxed).into();
+        TraceId::from_bytes(trace_id.to_be_bytes())
     }
 
     fn new_span_id(&self) -> opentelemetry::trace::SpanId {
-        SpanId::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed))
+        SpanId::from_bytes(
+            self.next_span_id
+                .fetch_add(1, Ordering::Relaxed)
+                .to_be_bytes(),
+        )
     }
 }
 

--- a/logfire/src/test_utils.rs
+++ b/logfire/src/test_utils.rs
@@ -98,14 +98,14 @@ impl<Inner: SpanExporter> SpanExporter for DeterministicExporter<Inner> {
 
                 // to minimize churn on tests, remap line numbers in the test to be relative to
                 // the test function
-                if attr.key.as_str() == "code.filepath" && attr.value.as_str() == self.file {
+                if attr.key.as_str() == "code.file.path" && attr.value.as_str() == self.file {
                     remap_line = true;
                 }
             }
 
             if remap_line {
                 for attr in &mut span.attributes {
-                    if attr.key.as_str() == "code.lineno" {
+                    if attr.key.as_str() == "code.line.number" {
                         if let Value::I64(line) = &mut attr.value {
                             *line -= i64::from(self.line_offset);
                         }
@@ -384,7 +384,7 @@ pub fn make_deterministic_logs(
             // Check if we need to remap line numbers for this file
             let mut remap_line = false;
             for (key, value) in original_record.attributes_iter() {
-                if key.as_str() == "code.filepath" {
+                if key.as_str() == "code.file.path" {
                     if let opentelemetry::logs::AnyValue::String(s) = value {
                         if s.as_str() == file {
                             remap_line = true;
@@ -400,7 +400,7 @@ pub fn make_deterministic_logs(
             for (key, value) in original_record.attributes_iter() {
                 let new_value = match key.as_str() {
                     "thread.id" => opentelemetry::logs::AnyValue::Int(0),
-                    "code.lineno" if remap_line => {
+                    "code.line.number" if remap_line => {
                         if let opentelemetry::logs::AnyValue::Int(line) = value {
                             opentelemetry::logs::AnyValue::Int(line - i64::from(line_offset))
                         } else {

--- a/logfire/tests/test_basic_exports.rs
+++ b/logfire/tests/test_basic_exports.rs
@@ -91,136 +91,11 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
-            span_kind: Internal,
-            name: "root span",
-            start_time: SystemTime {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "logfire/tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        32,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "root span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        9,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f3,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f2,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "hello world span",
             start_time: SystemTime {
-                tv_sec: 1,
+                tv_sec: 0,
                 tv_nsec: 0,
             },
             end_time: SystemTime {
@@ -230,7 +105,7 @@ fn test_basic_span() {
             attributes: [
                 KeyValue {
                     key: Static(
-                        "code.filepath",
+                        "code.file.path",
                     ),
                     value: String(
                         Static(
@@ -240,7 +115,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.namespace",
+                        "code.module.name",
                     ),
                     value: String(
                         Static(
@@ -250,7 +125,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.lineno",
+                        "code.line.number",
                     ),
                     value: I64(
                         33,
@@ -324,22 +199,18 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "logfire.span_type",
+                        "busy_ns",
                     ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
+                    value: I64(
+                        0,
                     ),
                 },
                 KeyValue {
                     key: Static(
-                        "logfire.pending_parent_id",
+                        "idle_ns",
                     ),
-                    value: String(
-                        Owned(
-                            "00000000000000f0",
-                        ),
+                    value: I64(
+                        0,
                     ),
                 },
             ],
@@ -373,174 +244,13 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
-            name: "hello world span",
+            name: "debug span",
             start_time: SystemTime {
-                tv_sec: 1,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
                 tv_sec: 2,
                 tv_nsec: 0,
             },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "logfire/tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        33,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "attr",
-                    ),
-                    value: String(
-                        Owned(
-                            "x",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "dotted.attr",
-                    ),
-                    value: String(
-                        Owned(
-                            "y",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "hello world span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{\"attr\":{},\"dotted.attr\":{}}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        9,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "busy_ns",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "idle_ns",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f5,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f4,
-            span_kind: Internal,
-            name: "debug span",
-            start_time: SystemTime {
-                tv_sec: 3,
-                tv_nsec: 0,
-            },
             end_time: SystemTime {
                 tv_sec: 3,
                 tv_nsec: 0,
@@ -548,7 +258,7 @@ fn test_basic_span() {
             attributes: [
                 KeyValue {
                     key: Static(
-                        "code.filepath",
+                        "code.file.path",
                     ),
                     value: String(
                         Static(
@@ -558,7 +268,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.namespace",
+                        "code.module.name",
                     ),
                     value: String(
                         Static(
@@ -568,7 +278,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.lineno",
+                        "code.line.number",
                     ),
                     value: I64(
                         34,
@@ -622,22 +332,18 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "logfire.span_type",
+                        "busy_ns",
                     ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
+                    value: I64(
+                        0,
                     ),
                 },
                 KeyValue {
                     key: Static(
-                        "logfire.pending_parent_id",
+                        "idle_ns",
                     ),
-                    value: String(
-                        Owned(
-                            "00000000000000f0",
-                        ),
+                    value: I64(
+                        0,
                     ),
                 },
             ],
@@ -661,7 +367,7 @@ fn test_basic_span() {
         SpanData {
             span_context: SpanContext {
                 trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f4,
+                span_id: 00000000000000f3,
                 trace_flags: TraceFlags(
                     1,
                 ),
@@ -671,154 +377,13 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 00000000000000f0,
+            parent_span_is_remote: false,
             span_kind: Internal,
-            name: "debug span",
+            name: "debug span with explicit parent",
             start_time: SystemTime {
-                tv_sec: 3,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
                 tv_sec: 4,
                 tv_nsec: 0,
             },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "logfire/tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        34,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "debug span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        5,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "busy_ns",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "idle_ns",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f7,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f6,
-            span_kind: Internal,
-            name: "debug span with explicit parent",
-            start_time: SystemTime {
-                tv_sec: 5,
-                tv_nsec: 0,
-            },
             end_time: SystemTime {
                 tv_sec: 5,
                 tv_nsec: 0,
@@ -826,7 +391,7 @@ fn test_basic_span() {
             attributes: [
                 KeyValue {
                     key: Static(
-                        "code.filepath",
+                        "code.file.path",
                     ),
                     value: String(
                         Static(
@@ -836,7 +401,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.namespace",
+                        "code.module.name",
                     ),
                     value: String(
                         Static(
@@ -846,7 +411,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.lineno",
+                        "code.line.number",
                     ),
                     value: I64(
                         35,
@@ -896,152 +461,6 @@ fn test_basic_span() {
                     ),
                     value: I64(
                         5,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "pending_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.pending_parent_id",
-                    ),
-                    value: String(
-                        Owned(
-                            "00000000000000f0",
-                        ),
-                    ),
-                },
-            ],
-            dropped_attributes_count: 0,
-            events: SpanEvents {
-                events: [],
-                dropped_count: 0,
-            },
-            links: SpanLinks {
-                links: [],
-                dropped_count: 0,
-            },
-            status: Unset,
-            instrumentation_scope: InstrumentationScope {
-                name: "logfire",
-                version: None,
-                schema_url: None,
-                attributes: [],
-            },
-        },
-        SpanData {
-            span_context: SpanContext {
-                trace_id: 000000000000000000000000000000f0,
-                span_id: 00000000000000f6,
-                trace_flags: TraceFlags(
-                    1,
-                ),
-                is_remote: false,
-                trace_state: TraceState(
-                    None,
-                ),
-            },
-            parent_span_id: 00000000000000f0,
-            span_kind: Internal,
-            name: "debug span with explicit parent",
-            start_time: SystemTime {
-                tv_sec: 5,
-                tv_nsec: 0,
-            },
-            end_time: SystemTime {
-                tv_sec: 6,
-                tv_nsec: 0,
-            },
-            attributes: [
-                KeyValue {
-                    key: Static(
-                        "code.filepath",
-                    ),
-                    value: String(
-                        Static(
-                            "logfire/tests/test_basic_exports.rs",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.namespace",
-                    ),
-                    value: String(
-                        Static(
-                            "test_basic_exports",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "code.lineno",
-                    ),
-                    value: I64(
-                        35,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.id",
-                    ),
-                    value: I64(
-                        0,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "thread.name",
-                    ),
-                    value: String(
-                        Owned(
-                            "test_basic_span",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.msg",
-                    ),
-                    value: String(
-                        Owned(
-                            "debug span with explicit parent",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.json_schema",
-                    ),
-                    value: String(
-                        Owned(
-                            "{\"type\":\"object\",\"properties\":{}}",
-                        ),
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.level_num",
-                    ),
-                    value: I64(
-                        5,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "span",
-                        ),
                     ),
                 },
                 KeyValue {
@@ -1091,10 +510,11 @@ fn test_basic_span() {
                 ),
             },
             parent_span_id: 0000000000000000,
+            parent_span_is_remote: false,
             span_kind: Internal,
             name: "root span",
             start_time: SystemTime {
-                tv_sec: 0,
+                tv_sec: 6,
                 tv_nsec: 0,
             },
             end_time: SystemTime {
@@ -1104,7 +524,7 @@ fn test_basic_span() {
             attributes: [
                 KeyValue {
                     key: Static(
-                        "code.filepath",
+                        "code.file.path",
                     ),
                     value: String(
                         Static(
@@ -1114,7 +534,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.namespace",
+                        "code.module.name",
                     ),
                     value: String(
                         Static(
@@ -1124,7 +544,7 @@ fn test_basic_span() {
                 },
                 KeyValue {
                     key: Static(
-                        "code.lineno",
+                        "code.line.number",
                     ),
                     value: I64(
                         32,
@@ -1174,16 +594,6 @@ fn test_basic_span() {
                     ),
                     value: I64(
                         9,
-                    ),
-                },
-                KeyValue {
-                    key: Static(
-                        "logfire.span_type",
-                    ),
-                    value: String(
-                        Static(
-                            "span",
-                        ),
                     ),
                 },
                 KeyValue {
@@ -1286,7 +696,7 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "code.filepath",
+                                    "code.file.path",
                                 ),
                                 String(
                                     Static(
@@ -1298,7 +708,7 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "code.lineno",
+                                    "code.line.number",
                                 ),
                                 Int(
                                     36,
@@ -1308,7 +718,7 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "code.namespace",
+                                    "code.module.name",
                                 ),
                                 String(
                                     Static(
@@ -1441,7 +851,7 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "code.filepath",
+                                    "code.file.path",
                                 ),
                                 String(
                                     Owned(
@@ -1453,7 +863,7 @@ fn test_basic_span() {
                         Some(
                             (
                                 Static(
-                                    "code.lineno",
+                                    "code.line.number",
                                 ),
                                 Int(
                                     37,

--- a/logfire/tests/test_grpc_sink.rs
+++ b/logfire/tests/test_grpc_sink.rs
@@ -254,7 +254,7 @@ async fn test_grpc_protobuf_export() {
                                         AnyValue {
                                             value: Some(
                                                 StringValue(
-                                                    "0.30.0",
+                                                    "0.31.0",
                                                 ),
                                             ),
                                         },
@@ -307,7 +307,7 @@ async fn test_grpc_protobuf_export() {
                                     ],
                                     trace_state: "",
                                     parent_span_id: [],
-                                    flags: 1,
+                                    flags: 257,
                                     name: "grpc_test_span",
                                     kind: Internal,
                                     start_time_unix_nano: 0,
@@ -326,7 +326,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.filepath",
+                                            key: "code.file.path",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -338,7 +338,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.lineno",
+                                            key: "code.line.number",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -350,7 +350,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.namespace",
+                                            key: "code.module.name",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -404,18 +404,6 @@ async fn test_grpc_protobuf_export() {
                                                     value: Some(
                                                         StringValue(
                                                             "grpc_test_span",
-                                                        ),
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                        KeyValue {
-                                            key: "logfire.span_type",
-                                            value: Some(
-                                                AnyValue {
-                                                    value: Some(
-                                                        StringValue(
-                                                            "span",
                                                         ),
                                                     ),
                                                 },
@@ -523,7 +511,7 @@ async fn test_grpc_protobuf_export() {
                                         AnyValue {
                                             value: Some(
                                                 StringValue(
-                                                    "0.30.0",
+                                                    "0.31.0",
                                                 ),
                                             ),
                                         },
@@ -561,7 +549,7 @@ async fn test_grpc_protobuf_export() {
                                     ),
                                     attributes: [
                                         KeyValue {
-                                            key: "code.filepath",
+                                            key: "code.file.path",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -573,7 +561,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.lineno",
+                                            key: "code.line.number",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -585,7 +573,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.namespace",
+                                            key: "code.module.name",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -681,7 +669,7 @@ async fn test_grpc_protobuf_export() {
                                     ),
                                     attributes: [
                                         KeyValue {
-                                            key: "code.filepath",
+                                            key: "code.file.path",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -693,7 +681,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.lineno",
+                                            key: "code.line.number",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(
@@ -705,7 +693,7 @@ async fn test_grpc_protobuf_export() {
                                             ),
                                         },
                                         KeyValue {
-                                            key: "code.namespace",
+                                            key: "code.module.name",
                                             value: Some(
                                                 AnyValue {
                                                     value: Some(

--- a/logfire/tests/test_http_sink.rs
+++ b/logfire/tests/test_http_sink.rs
@@ -114,7 +114,7 @@ async fn test_http_protobuf_export() {
                                     AnyValue {
                                         value: Some(
                                             StringValue(
-                                                "0.30.0",
+                                                "0.31.0",
                                             ),
                                         ),
                                     },
@@ -167,7 +167,7 @@ async fn test_http_protobuf_export() {
                                 ],
                                 trace_state: "",
                                 parent_span_id: [],
-                                flags: 1,
+                                flags: 257,
                                 name: "test_span",
                                 kind: Internal,
                                 start_time_unix_nano: 0,
@@ -186,7 +186,7 @@ async fn test_http_protobuf_export() {
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.filepath",
+                                        key: "code.file.path",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
@@ -198,7 +198,7 @@ async fn test_http_protobuf_export() {
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.lineno",
+                                        key: "code.line.number",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
@@ -210,7 +210,7 @@ async fn test_http_protobuf_export() {
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.namespace",
+                                        key: "code.module.name",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
@@ -264,18 +264,6 @@ async fn test_http_protobuf_export() {
                                                 value: Some(
                                                     StringValue(
                                                         "test_span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.span_type",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "span",
                                                     ),
                                                 ),
                                             },
@@ -430,7 +418,7 @@ async fn test_http_json_export() {
                                     AnyValue {
                                         value: Some(
                                             StringValue(
-                                                "0.30.0",
+                                                "0.31.0",
                                             ),
                                         ),
                                     },
@@ -483,7 +471,7 @@ async fn test_http_json_export() {
                                 ],
                                 trace_state: "",
                                 parent_span_id: [],
-                                flags: 1,
+                                flags: 257,
                                 name: "json_test_span",
                                 kind: Internal,
                                 start_time_unix_nano: 0,
@@ -502,7 +490,7 @@ async fn test_http_json_export() {
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.filepath",
+                                        key: "code.file.path",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
@@ -514,19 +502,19 @@ async fn test_http_json_export() {
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.lineno",
+                                        key: "code.line.number",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
                                                     IntValue(
-                                                        370,
+                                                        358,
                                                     ),
                                                 ),
                                             },
                                         ),
                                     },
                                     KeyValue {
-                                        key: "code.namespace",
+                                        key: "code.module.name",
                                         value: Some(
                                             AnyValue {
                                                 value: Some(
@@ -580,18 +568,6 @@ async fn test_http_json_export() {
                                                 value: Some(
                                                     StringValue(
                                                         "json_test_span",
-                                                    ),
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                    KeyValue {
-                                        key: "logfire.span_type",
-                                        value: Some(
-                                            AnyValue {
-                                                value: Some(
-                                                    StringValue(
-                                                        "span",
                                                     ),
                                                 ),
                                             },


### PR DESCRIPTION
This updates the `tracing` integration to work around the changes to `tracing-opentelemetry` made in the 0.32 release (corresponding to 0.31 version of the otel sdks).

The big change is that `tracing-opentelemetry` now synchronizes tracing with an otel span eagerly, which I think should enable us to have a cleaner & more consistent implementation.

Otel 0.31 SDKs have made some changes to attributes:
- `code.lineno` -> `code.line.number`
- `code.filepath` -> `code.file.path`
- `code.namespace` -> `code.module.name`

I've updated the locations where we produce these attributes from within the SDK for consistency.