### PR TITLE
ci: make a clean test run with `--no-default-features`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,8 @@ jobs:
     - id: cache-rust
       uses: Swatinem/rust-cache@v2
 
+    - run: cargo test --workspace --no-default-features
+
     - uses: taiki-e/install-action@cargo-llvm-cov
 
     - run: cargo llvm-cov --workspace --all-features --codecov --output-path codecov.json

--- a/logfire/Cargo.toml
+++ b/logfire/Cargo.toml
@@ -127,3 +127,7 @@ unwrap_used = "deny"
 # certain lints which we don't want to enforce (for now)
 pedantic = { level = "deny", priority = -1 }
 implicit_hasher = "allow"
+
+[[test]]
+name = "test_http_sink"
+required-features = ["export-http-json"]

--- a/logfire/src/exporters.rs
+++ b/logfire/src/exporters.rs
@@ -1,16 +1,20 @@
-//! Helper functions to configure mo
+#![cfg_attr(
+    not(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    )),
+    expect(unreachable_code, unused_variables)
+)]
+//! Helper functions to configure exporters via OTLP.
 use std::collections::HashMap;
 
-use opentelemetry_otlp::{LogExporter, MetricExporter, Protocol};
+use opentelemetry_otlp::Protocol;
 use opentelemetry_sdk::{
-    logs::LogExporter as LogExporterTrait, metrics::exporter::PushMetricExporter,
-    trace::SpanExporter,
+    logs::LogExporter, metrics::exporter::PushMetricExporter, trace::SpanExporter,
 };
 
-use crate::{
-    ConfigureError, internal::env::get_optional_env,
-    internal::exporters::remove_pending::RemovePendingSpansExporter,
-};
+use crate::{ConfigureError, internal::env::get_optional_env};
 
 macro_rules! feature_required {
     ($feature_name:literal, $functionality:expr, $if_enabled:expr) => {{
@@ -50,8 +54,6 @@ pub fn span_exporter(
 ) -> Result<impl SpanExporter + use<>, ConfigureError> {
     let (source, protocol) = protocol_from_env("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")?;
 
-    let builder = opentelemetry_otlp::SpanExporter::builder();
-
     // FIXME: it would be nice to let `opentelemetry-rust` handle this; ideally we could detect if
     // OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_TRACES_PROTOCOL is set and let the SDK
     // make a builder. (If unset, we could supply our preferred exporter.)
@@ -63,7 +65,7 @@ pub fn span_exporter(
             Protocol::Grpc => {
                 feature_required!("export-grpc", source, {
                     use opentelemetry_otlp::WithTonicConfig;
-                    builder
+                    opentelemetry_otlp::SpanExporter::builder()
                         .with_tonic()
                         .with_channel(
                             tonic::transport::Channel::builder(endpoint.try_into().map_err(
@@ -78,7 +80,7 @@ pub fn span_exporter(
             Protocol::HttpBinary => {
                 feature_required!("export-http-protobuf", source, {
                     use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                    builder
+                    opentelemetry_otlp::SpanExporter::builder()
                         .with_http()
                         .with_protocol(Protocol::HttpBinary)
                         .with_headers(headers.unwrap_or_default())
@@ -89,7 +91,7 @@ pub fn span_exporter(
             Protocol::HttpJson => {
                 feature_required!("export-http-json", source, {
                     use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                    builder
+                    opentelemetry_otlp::SpanExporter::builder()
                         .with_http()
                         .with_protocol(Protocol::HttpJson)
                         .with_headers(headers.unwrap_or_default())
@@ -98,7 +100,19 @@ pub fn span_exporter(
                 })
             }
         };
-    Ok(RemovePendingSpansExporter::new(span_exporter))
+
+    cfg_select! {
+        not(any(
+            feature = "export-grpc",
+            feature = "export-http-protobuf",
+            feature = "export-http-json"
+        )) => {
+            {
+                Ok(UnreachableExporter)
+            }
+        }
+        _ => Ok(crate::internal::exporters::remove_pending::RemovePendingSpansExporter::new(span_exporter))
+    }
 }
 
 /// Build a [`PushMetricExporter`] for passing to
@@ -121,9 +135,6 @@ pub fn metric_exporter(
 ) -> Result<impl PushMetricExporter + use<>, ConfigureError> {
     let (source, protocol) = protocol_from_env("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")?;
 
-    let builder =
-        MetricExporter::builder().with_temporality(opentelemetry_sdk::metrics::Temporality::Delta);
-
     // FIXME: it would be nice to let `opentelemetry-rust` handle this; ideally we could detect if
     // OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_METRICS_PROTOCOL is set and let the SDK
     // make a builder. (If unset, we could supply our preferred exporter.)
@@ -134,7 +145,8 @@ pub fn metric_exporter(
         Protocol::Grpc => {
             feature_required!("export-grpc", source, {
                 use opentelemetry_otlp::WithTonicConfig;
-                Ok(builder
+                Ok(opentelemetry_otlp::MetricExporter::builder()
+                    .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
                     .with_tonic()
                     .with_channel(
                         tonic::transport::Channel::builder(
@@ -151,7 +163,8 @@ pub fn metric_exporter(
         Protocol::HttpBinary => {
             feature_required!("export-http-protobuf", source, {
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                Ok(builder
+                Ok(opentelemetry_otlp::MetricExporter::builder()
+                    .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
                     .with_http()
                     .with_protocol(Protocol::HttpBinary)
                     .with_headers(headers.unwrap_or_default())
@@ -162,7 +175,8 @@ pub fn metric_exporter(
         Protocol::HttpJson => {
             feature_required!("export-http-json", source, {
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                Ok(builder
+                Ok(opentelemetry_otlp::MetricExporter::builder()
+                    .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
                     .with_http()
                     .with_protocol(Protocol::HttpJson)
                     .with_headers(headers.unwrap_or_default())
@@ -170,6 +184,21 @@ pub fn metric_exporter(
                     .build()?)
             })
         }
+    }
+
+    #[cfg(not(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    )))]
+    #[expect(unreachable_code)]
+    {
+        // suppress unused var warnings
+        let _ = endpoint;
+        let _ = headers;
+        let _ = source;
+        let _ = protocol;
+        Ok(UnreachableExporter)
     }
 }
 
@@ -189,10 +218,8 @@ pub fn metric_exporter(
 pub fn log_exporter(
     endpoint: &str,
     headers: Option<HashMap<String, String>>,
-) -> Result<impl LogExporterTrait + use<>, ConfigureError> {
+) -> Result<impl LogExporter + use<>, ConfigureError> {
     let (source, protocol) = protocol_from_env("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL")?;
-
-    let builder = LogExporter::builder();
 
     // FIXME: it would be nice to let `opentelemetry-rust` handle this; ideally we could detect if
     // OTEL_EXPORTER_OTLP_PROTOCOL or OTEL_EXPORTER_OTLP_LOGS_PROTOCOL is set and let the SDK
@@ -204,7 +231,7 @@ pub fn log_exporter(
         Protocol::Grpc => {
             feature_required!("export-grpc", source, {
                 use opentelemetry_otlp::WithTonicConfig;
-                Ok(builder
+                Ok(opentelemetry_otlp::LogExporter::builder()
                     .with_tonic()
                     .with_channel(
                         tonic::transport::Channel::builder(
@@ -221,7 +248,7 @@ pub fn log_exporter(
         Protocol::HttpBinary => {
             feature_required!("export-http-protobuf", source, {
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                Ok(builder
+                Ok(opentelemetry_otlp::LogExporter::builder()
                     .with_http()
                     .with_protocol(Protocol::HttpBinary)
                     .with_headers(headers.unwrap_or_default())
@@ -232,7 +259,7 @@ pub fn log_exporter(
         Protocol::HttpJson => {
             feature_required!("export-http-json", source, {
                 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
-                Ok(builder
+                Ok(opentelemetry_otlp::LogExporter::builder()
                     .with_http()
                     .with_protocol(Protocol::HttpJson)
                     .with_headers(headers.unwrap_or_default())
@@ -240,6 +267,21 @@ pub fn log_exporter(
                     .build()?)
             })
         }
+    }
+
+    #[cfg(not(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    )))]
+    #[expect(unreachable_code)]
+    {
+        // suppress unused var warnings
+        let _ = endpoint;
+        let _ = headers;
+        let _ = source;
+        let _ = protocol;
+        Ok(UnreachableExporter)
     }
 }
 
@@ -302,4 +344,71 @@ fn protocol_from_env(data_env_var: &str) -> Result<(String, Protocol), Configure
             },
             |(var_name, value)| Ok((format!("`{var_name}={value}`"), protocol_from_str(&value)?)),
         )
+}
+
+/// Internal type used when no export features are available to allow for type inference
+/// for impl Trait return of `span_exporter()`, `metric_exporter()`, or `log_exporter()`.
+#[cfg(not(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+)))]
+#[derive(Debug)]
+struct UnreachableExporter;
+
+#[cfg(not(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+)))]
+impl SpanExporter for UnreachableExporter {
+    fn export(
+        &self,
+        _batch: Vec<opentelemetry_sdk::trace::SpanData>,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        async { unreachable!() }
+    }
+}
+
+#[cfg(not(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+)))]
+impl PushMetricExporter for UnreachableExporter {
+    fn export(
+        &self,
+        _metrics: &opentelemetry_sdk::metrics::data::ResourceMetrics,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        async { unreachable!() }
+    }
+
+    fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+        unreachable!()
+    }
+
+    fn shutdown_with_timeout(
+        &self,
+        _timeout: std::time::Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        unreachable!()
+    }
+
+    fn temporality(&self) -> opentelemetry_sdk::metrics::Temporality {
+        unreachable!()
+    }
+}
+
+#[cfg(not(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+)))]
+impl LogExporter for UnreachableExporter {
+    fn export(
+        &self,
+        _batch: opentelemetry_sdk::logs::LogBatch<'_>,
+    ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send {
+        async { unreachable!() }
+    }
 }

--- a/logfire/src/exporters.rs
+++ b/logfire/src/exporters.rs
@@ -101,17 +101,26 @@ pub fn span_exporter(
             }
         };
 
-    cfg_select! {
-        not(any(
-            feature = "export-grpc",
-            feature = "export-http-protobuf",
-            feature = "export-http-json"
-        )) => {
-            {
-                Ok(UnreachableExporter)
-            }
-        }
-        _ => Ok(crate::internal::exporters::remove_pending::RemovePendingSpansExporter::new(span_exporter))
+    #[cfg(not(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    )))]
+    {
+        Ok(UnreachableExporter)
+    }
+
+    #[cfg(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    ))]
+    {
+        Ok(
+            crate::internal::exporters::remove_pending::RemovePendingSpansExporter::new(
+                span_exporter,
+            ),
+        )
     }
 }
 

--- a/logfire/src/internal/exporters/remove_pending.rs
+++ b/logfire/src/internal/exporters/remove_pending.rs
@@ -1,3 +1,12 @@
+#![cfg_attr(
+    not(any(
+        feature = "export-grpc",
+        feature = "export-http-protobuf",
+        feature = "export-http-json"
+    )),
+    expect(dead_code)
+)]
+
 use std::collections::HashMap;
 
 use opentelemetry_sdk::{

--- a/logfire/src/logfire.rs
+++ b/logfire/src/logfire.rs
@@ -34,6 +34,8 @@ use tracing::{Subscriber, level_filters::LevelFilter, subscriber::DefaultGuard};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, registry::LookupSpan};
 
+#[cfg(feature = "data-dir")]
+use crate::internal::env::get_optional_env;
 use crate::{
     __macros_impl::LogfireValue,
     ConfigureError, LogfireConfigBuilder, ShutdownError,
@@ -43,7 +45,6 @@ use crate::{
         LOGFIRE_SERVICE_VERSION, LOGFIRE_TOKEN_VALUE, SendToLogfire,
     },
     internal::{
-        env::get_optional_env,
         exporters::console::{ConsoleWriter, create_console_processors},
         log_processor_shutdown_hack::LogProcessorShutdownHack,
         logfire_tracer::{GLOBAL_TRACER, LOCAL_TRACER, LogfireTracer},
@@ -151,6 +152,7 @@ impl Logfire {
     ///
     /// let logfire = logfire::configure()
     ///    .local()  // use local mode to avoid setting global state
+    /// #  .send_to_logfire(false)  // avoid sending to logfire in tests
     ///    .finish()
     ///    .expect("Failed to configure logfire");
     ///
@@ -280,12 +282,12 @@ impl Logfire {
         config: LogfireConfigBuilder,
         env: Option<&HashMap<String, String>>,
     ) -> Result<LogfireParts, ConfigureError> {
-        let mut token = LOGFIRE_TOKEN_VALUE.resolve(config.token, env)?;
-
         #[cfg_attr(
             not(feature = "data-dir"),
             expect(unused_mut, reason = "only mutated on data-dir feature")
         )]
+        let mut token = LOGFIRE_TOKEN_VALUE.resolve(config.token, env)?;
+
         let mut advanced_options = config.advanced.unwrap_or_default();
 
         // Resolve LOGFIRE_BASE_URL env var (takes precedence over credentials file)
@@ -860,6 +862,12 @@ mod tests {
                 Ok(false),
             ),
         ] {
+            if cfg!(not(feature = "export-http-protobuf")) && matches!(expected, Ok(true)) {
+                // if the expected result is to send to logfire, we will attempt to configure the
+                // HTTP exporter, so avoid the test if the feature is disabled (will error)
+                continue;
+            }
+
             let env: std::collections::HashMap<String, String> =
                 env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
 
@@ -1216,6 +1224,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "export-http-protobuf")]
     fn test_base_url_from_env_var() {
         let env: std::collections::HashMap<String, String> = [
             (
@@ -1238,6 +1247,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "export-http-protobuf")]
     fn test_base_url_programmatic_overrides_env() {
         use crate::config::AdvancedOptions;
 
@@ -1263,6 +1273,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "export-http-protobuf")]
     fn test_token_from_env_var() {
         let env: std::collections::HashMap<String, String> =
             [("LOGFIRE_TOKEN".into(), "env-token".into())]


### PR DESCRIPTION
I noticed that `cargo test --no-default-features` failed to build, thought I would fix.