### PR TITLE
release: logfire 0.10.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,14 +8,17 @@ Each crate is versioned and released independently using prefixed git tags:
 | `logfire-core` | `logfire-core-v{version}` | `logfire-core-v0.1.0` |
 | `logfire-client` | `logfire-client-v{version}` | `logfire-client-v0.1.0` |
 
-To release a crate:
+To release:
 
-1. Update version in `{crate}/Cargo.toml`
-2. Update `[workspace.dependencies]` in root `Cargo.toml` if releasing `logfire-core`
-3. Commit: `git commit -am "Release {crate} v{version}"`
-4. Tag: `git tag {crate}-v{version}`
-5. Push: `git push && git push --tags`
+1. In a PR: bump the version in each `{crate}/Cargo.toml` being released (and
+   `[workspace.dependencies]` in the root `Cargo.toml` if releasing
+   `logfire-core`), update `logfire/CHANGELOG.md`, and merge to `main`.
+2. From `main`, run `./release.sh`. It reads the versions from `Cargo.toml`,
+   shows a plan, and pushes the `{crate}-v{version}` tags in dependency order:
+   `logfire-core` first (waiting for it to land on crates.io), then `logfire`
+   and `logfire-client`. Use `--dry-run` to preview or `--yes` to skip the
+   prompt.
 
-CI will automatically publish to crates.io when the tag is pushed.
-
-When releasing `logfire` or `logfire-client`, ensure `logfire-core` is published first if it has changes.
+CI (`.github/workflows/main.yml`) publishes each crate to crates.io when its
+tag is pushed. `logfire` and `logfire-client` depend on `logfire-core`, so it
+must be published first — `release.sh` enforces this ordering.

--- a/logfire/CHANGELOG.md
+++ b/logfire/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v0.10.0] (2026-06-08)
+
+* Add `LOGFIRE_BASE_URL` env var support and refactor `LOGFIRE_TOKEN` by @adriangb in [#119](https://github.com/pydantic/logfire-rust/pull/119)
+* Move `logfire` crate to subdirectory by @marc-pydantic in [#120](https://github.com/pydantic/logfire-rust/pull/120)
+* Add `logfire-client` crate by @marc-pydantic in [#121](https://github.com/pydantic/logfire-rust/pull/121)
+* add metrics interface scoped to local `Logfire` instance by @davidhewitt in [#126](https://github.com/pydantic/logfire-rust/pull/126)
+* update to opentelemetry 0.31 by @davidhewitt in [#124](https://github.com/pydantic/logfire-rust/pull/124)
+
 ## [v0.9.0] (2025-11-06)
 
 * support setting service resource attributes from environment variable by @davidhewitt in [#109](https://github.com/pydantic/logfire-rust/pull/109)
@@ -111,3 +119,4 @@ Initial release.
 [v0.8.1]: https://github.com/pydantic/logfire-rust/compare/v0.8.0..v0.8.1
 [v0.8.2]: https://github.com/pydantic/logfire-rust/compare/v0.8.1..v0.8.2
 [v0.9.0]: https://github.com/pydantic/logfire-rust/compare/v0.8.2..v0.9.0
+[v0.10.0]: https://github.com/pydantic/logfire-rust/compare/logfire-v0.9.0..logfire-v0.10.0

--- a/logfire/Cargo.toml
+++ b/logfire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logfire"
-version = "0.9.0"
+version = "0.10.0"
 description = "Rust SDK for Pydantic Logfire"
 documentation = "https://docs.rs/logfire"
 homepage = "https://github.com/pydantic/logfire-rust"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Cut a release by pushing crate-prefixed git tags in dependency order.
+#
+# Actual publishing is done by CI (.github/workflows/main.yml): pushing a tag
+# matching `{crate}-v*` runs `cargo publish -p {crate}` once tests/lint pass.
+# This script only creates and pushes those tags.
+#
+# Why ordering matters: `logfire` and `logfire-client` both depend on
+# `logfire-core` via a version requirement, so `logfire-core` must be live on
+# crates.io *before* their tags are pushed. This script tags `logfire-core`
+# first, waits for it to appear on crates.io, then tags the dependents.
+#
+# Versions are read straight from each crate's Cargo.toml — bump them (and the
+# CHANGELOG) in a separate PR and merge to main before running this.
+#
+# Usage:
+#   ./release.sh            # show the plan, then prompt before pushing tags
+#   ./release.sh --yes      # skip the confirmation prompt
+#   ./release.sh --dry-run  # show the plan and exit without tagging
+
+set -euo pipefail
+
+ASSUME_YES=false
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) ASSUME_YES=true ;;
+    --dry-run|-n) DRY_RUN=true ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Crates in publish order. logfire-core has no intra-workspace deps and must be
+# first; logfire and logfire-client depend on it.
+CRATES=(logfire-core logfire logfire-client)
+
+crate_version() {
+  # First `version = "..."` line in the crate's Cargo.toml.
+  grep -m1 '^version = ' "$1/Cargo.toml" | sed -E 's/^version = "(.*)"/\1/'
+}
+
+is_published() {
+  # Succeeds if the exact {crate} {version} already exists on crates.io.
+  curl -fsS "https://crates.io/api/v1/crates/$1/$2" >/dev/null 2>&1
+}
+
+wait_for_publish() {
+  local crate="$1" version="$2"
+  echo "Waiting for $crate $version to appear on crates.io (CI is publishing)..."
+  for _ in $(seq 1 90); do
+    if is_published "$crate" "$version"; then
+      echo "  $crate $version is live."
+      return 0
+    fi
+    sleep 10
+  done
+  echo "  timed out after 15m waiting for $crate $version" >&2
+  return 1
+}
+
+# --- pre-flight checks -------------------------------------------------------
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" != "main" ]; then
+  echo "warning: you are on '$branch', not 'main'. Releases are normally cut from main." >&2
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean; commit or stash first." >&2
+  exit 1
+fi
+
+echo "Fetching tags from origin..."
+git fetch --quiet --tags origin
+
+# --- build the plan ----------------------------------------------------------
+
+declare -a to_tag_crate to_tag_version
+echo
+echo "Release plan:"
+for crate in "${CRATES[@]}"; do
+  version=$(crate_version "$crate")
+  tag="$crate-v$version"
+  if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+    echo "  $crate $version — tag $tag already exists locally, skip"
+  elif is_published "$crate" "$version"; then
+    echo "  $crate $version — already on crates.io, skip"
+  else
+    echo "  $crate $version — will tag and push '$tag'"
+    to_tag_crate+=("$crate")
+    to_tag_version+=("$version")
+  fi
+done
+
+if [ "${#to_tag_crate[@]}" -eq 0 ]; then
+  echo
+  echo "Nothing to release. All crate versions are already tagged or published."
+  exit 0
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  echo
+  echo "(dry run — no tags pushed)"
+  exit 0
+fi
+
+if [ "$ASSUME_YES" != true ]; then
+  echo
+  read -r -p "Push these tags? [y/N] " reply
+  case "$reply" in
+    y|Y|yes|Yes) ;;
+    *) echo "aborted."; exit 1 ;;
+  esac
+fi
+
+# --- push tags in dependency order -------------------------------------------
+
+for i in "${!to_tag_crate[@]}"; do
+  crate="${to_tag_crate[$i]}"
+  version="${to_tag_version[$i]}"
+  tag="$crate-v$version"
+
+  echo
+  echo "Tagging $tag..."
+  git tag -a "$tag" -m "$crate $version"
+  git push origin "$tag"
+  echo "Pushed $tag — CI will publish $crate $version."
+
+  # logfire-core must be live before the crates that depend on it are tagged.
+  if [ "$crate" = "logfire-core" ]; then
+    wait_for_publish logfire-core "$version"
+  fi
+done
+
+echo
+echo "Done. Watch CI for publish status: https://github.com/pydantic/logfire-rust/actions"


### PR DESCRIPTION
Prep for the next release.

## `logfire` 0.9.0 → 0.10.0

Changes since `logfire-v0.9.0`:

* Add `LOGFIRE_BASE_URL` env var support and refactor `LOGFIRE_TOKEN` (#119)
* Move `logfire` crate to subdirectory (#120)
* Add `logfire-client` crate (#121)
* add metrics interface scoped to local `Logfire` instance (#126)
* update to opentelemetry 0.31 (#124)

Minor bump justified by the OpenTelemetry 0.31 upgrade (otel types are exposed in the public API), consistent with prior otel-bump releases (0.5.0, 0.6.0).

## New crates — first publish (no version change)

`logfire-core` (0.1.0) and `logfire-client` (0.1.0) were added in this cycle and have never been published.

## Release tooling: `release.sh`

Added `release.sh` (and updated `DEVELOPMENT.md`). Releases are done by CI on tag push — `cargo publish` runs when a `{crate}-v*` tag lands. The script reads versions from `Cargo.toml` and pushes the tags **in dependency order**: `logfire-core` first, waits for it to appear on crates.io, then `logfire` + `logfire-client` (both depend on core, so it must be live before they publish).

```
./release.sh --dry-run   # preview the plan
./release.sh             # plan + confirm + push tags
```

## What this PR does NOT do

No tags pushed / nothing published. After merge, run `./release.sh` from `main`. Release order it will enforce:
1. `logfire-core-v0.1.0`
2. `logfire-v0.10.0` + `logfire-client-v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)