### PR TITLE
update `reqwest` dependency in `logfire-client` to 0.13

### DIFF
--- a/logfire-client/Cargo.toml
+++ b/logfire-client/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 logfire-core.workspace = true
 
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror.workspace = true


### PR DESCRIPTION
`rustls` feature was renamed, otherwise seems trivial.