### PR TITLE
release: logfire 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ rust-version = "1.91"
 repository = "https://github.com/pydantic/logfire-rust"
 
 [workspace.dependencies]
-logfire-core = { path = "logfire-core", version = "0.1.0" }
+logfire-core = { path = "logfire-core", version = "0.11.0" }
 thiserror = "2"

--- a/logfire-client/Cargo.toml
+++ b/logfire-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logfire-client"
-version = "0.1.0"
+version = "0.11.0"
 description = "Logfire client SDK, query your Pydantic Logfire logs and metrics using SQL!"
 edition.workspace = true
 license.workspace = true

--- a/logfire-core/Cargo.toml
+++ b/logfire-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logfire-core"
-version = "0.1.0"
+version = "0.11.0"
 description = "Shared types for Pydantic Logfire SDKs"
 edition.workspace = true
 license.workspace = true

--- a/logfire/CHANGELOG.md
+++ b/logfire/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.11.0] (2026-07-17)
+
+* bump opentelemetry to 0.32 by @davidhewitt in [#137](https://github.com/pydantic/logfire-rust/pull/137)
+* update `reqwest` dependency in `logfire-client` to 0.13 by @davidhewitt in [#136](https://github.com/pydantic/logfire-rust/pull/136)
+
 ## [v0.10.0] (2026-06-08)
 
 * Add `LOGFIRE_BASE_URL` env var support and refactor `LOGFIRE_TOKEN` by @adriangb in [#119](https://github.com/pydantic/logfire-rust/pull/119)

--- a/logfire/Cargo.toml
+++ b/logfire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logfire"
-version = "0.10.0"
+version = "0.11.0"
 description = "Rust SDK for Pydantic Logfire"
 documentation = "https://docs.rs/logfire"
 homepage = "https://github.com/pydantic/logfire-rust"


### PR DESCRIPTION
Bump all crates to 0.11.0 for a unified release:

- `logfire` 0.10.0 → 0.11.0
- `logfire-core` 0.1.0 → 0.11.0 (first crates.io publish)
- `logfire-client` 0.1.0 → 0.11.0 (first crates.io publish)

Context: the 0.10.0 release (#127) tagged GitHub but the per-crate tags that trigger crates.io publishing were never pushed, so crates.io is still on `logfire` 0.9.0 and `logfire-core`/`logfire-client` are unpublished. Since then main has picked up OTel 0.32 (#137) and reqwest 0.13 in `logfire-client` (#136), so rather than publish a "0.10.0" that doesn't match the v0.10.0 tag, this cuts 0.11.0 from current main. Needed by pydantic/platform#27544 to replace its git pin with a crates.io version.

After merge: run `./release.sh` from main to push the per-crate tags in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)