### PR TITLE
ci: publish releases from GitHub Releases via crates.io trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'logfire-v*'
-      - 'logfire-core-v*'
-      - 'logfire-client-v*'
   pull_request: {}
+  release:
+    types: [published]
 
 env:
   # avoid attempting to send logs to logfire from tests
@@ -102,41 +100,23 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-  release-logfire-core:
+  # Publishing a GitHub Release (tag v{version}) runs this once tests/lint pass
+  # on the tag. The `release` environment pauses the job for reviewer approval;
+  # the crates.io token is minted per-run via OIDC trusted publishing.
+  release:
     needs: [check]
-    if: "success() && startsWith(github.ref, 'refs/tags/logfire-core-v')"
+    if: "success() && github.event_name == 'release'"
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - run: cargo publish -p logfire-core
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: ./release.sh
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  release-logfire:
-    needs: [check]
-    if: "success() && startsWith(github.ref, 'refs/tags/logfire-v')"
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo publish -p logfire
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  release-logfire-client:
-    needs: [check]
-    if: "success() && startsWith(github.ref, 'refs/tags/logfire-client-v')"
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo publish -p logfire-client
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,24 +1,26 @@
 # Release Process
 
-Each crate is versioned and released independently using prefixed git tags:
-
-| Crate | Tag format | Example |
-|-------|------------|---------|
-| `logfire` | `logfire-v{version}` | `logfire-v0.9.0` |
-| `logfire-core` | `logfire-core-v{version}` | `logfire-core-v0.1.0` |
-| `logfire-client` | `logfire-client-v{version}` | `logfire-client-v0.1.0` |
+All crates (`logfire`, `logfire-core`, `logfire-client`) are versioned in
+lockstep and published together from a single GitHub Release tagged
+`v{version}`.
 
 To release:
 
-1. In a PR: bump the version in each `{crate}/Cargo.toml` being released (and
-   `[workspace.dependencies]` in the root `Cargo.toml` if releasing
-   `logfire-core`), update `logfire/CHANGELOG.md`, and merge to `main`.
-2. From `main`, run `./release.sh`. It reads the versions from `Cargo.toml`,
-   shows a plan, and pushes the `{crate}-v{version}` tags in dependency order:
-   `logfire-core` first (waiting for it to land on crates.io), then `logfire`
-   and `logfire-client`. Use `--dry-run` to preview or `--yes` to skip the
-   prompt.
+1. In a PR: bump `version` in every `{crate}/Cargo.toml` and the `logfire-core`
+   pin in `[workspace.dependencies]` in the root `Cargo.toml` (all to the same
+   version), update `logfire/CHANGELOG.md`, and merge to `main`.
+2. Publish a GitHub Release with a new `v{version}` tag on `main`, e.g.
+   `gh release create v0.12.0 --generate-notes`.
+3. CI (`.github/workflows/main.yml`) runs tests on the tag, then the `release`
+   job pauses in the `release` environment until a maintainer approves the
+   deployment. On approval it runs `./release.sh`, which checks that every
+   crate's version matches the tag and publishes with
+   `cargo publish --workspace` (`logfire-core` first — cargo orders
+   intra-workspace dependencies and waits for the index).
 
-CI (`.github/workflows/main.yml`) publishes each crate to crates.io when its
-tag is pushed. `logfire` and `logfire-client` depend on `logfire-core`, so it
-must be published first — `release.sh` enforces this ordering.
+Publishing authenticates via crates.io
+[trusted publishing](https://crates.io/docs/trusted-publishing): the job mints
+a short-lived OIDC token with `rust-lang/crates-io-auth-action` — there is no
+long-lived registry token. Each crate's trusted-publisher configuration on
+crates.io must name repository `pydantic/logfire-rust`, workflow `main.yml`,
+and environment `release`.

--- a/release.sh
+++ b/release.sh
@@ -1,38 +1,31 @@
 #!/usr/bin/env bash
 #
-# Cut a release by pushing crate-prefixed git tags in dependency order.
+# Publish all workspace crates to crates.io. Runs in CI
+# (.github/workflows/main.yml) when a GitHub Release is published: the release
+# job names the `release` environment, so it pauses for reviewer approval,
+# mints a short-lived crates.io token via OIDC trusted publishing, and then
+# runs this script.
 #
-# Actual publishing is done by CI (.github/workflows/main.yml): pushing a tag
-# matching `{crate}-v*` runs `cargo publish -p {crate}` once tests/lint pass.
-# This script only creates and pushes those tags.
-#
-# Why ordering matters: `logfire` and `logfire-client` both depend on
-# `logfire-core` via a version requirement, so `logfire-core` must be live on
-# crates.io *before* their tags are pushed. This script tags `logfire-core`
-# first, waits for it to appear on crates.io, then tags the dependents.
-#
-# Versions are read straight from each crate's Cargo.toml — bump them (and the
-# CHANGELOG) in a separate PR and merge to main before running this.
+# All crates are versioned in lockstep. This verifies every crate's Cargo.toml
+# version matches the release tag (`v{version}`), then publishes with
+# `cargo publish --workspace`, which orders intra-workspace dependencies
+# (`logfire-core` before `logfire` / `logfire-client`) and waits for each
+# publish to land in the index before publishing its dependents.
 #
 # Usage:
-#   ./release.sh            # show the plan, then prompt before pushing tags
-#   ./release.sh --yes      # skip the confirmation prompt
-#   ./release.sh --dry-run  # show the plan and exit without tagging
+#   ./release.sh            # verify + publish (CI; needs CARGO_REGISTRY_TOKEN)
+#   ./release.sh --dry-run  # verify versions + `cargo publish` dry run
 
 set -euo pipefail
 
-ASSUME_YES=false
 DRY_RUN=false
 for arg in "$@"; do
   case "$arg" in
-    --yes|-y) ASSUME_YES=true ;;
     --dry-run|-n) DRY_RUN=true ;;
     *) echo "unknown argument: $arg" >&2; exit 2 ;;
   esac
 done
 
-# Crates in publish order. logfire-core has no intra-workspace deps and must be
-# first; logfire and logfire-client depend on it.
 CRATES=(logfire-core logfire logfire-client)
 
 crate_version() {
@@ -40,98 +33,25 @@ crate_version() {
   grep -m1 '^version = ' "$1/Cargo.toml" | sed -E 's/^version = "(.*)"/\1/'
 }
 
-is_published() {
-  # Succeeds if the exact {crate} {version} already exists on crates.io.
-  curl -fsS "https://crates.io/api/v1/crates/$1/$2" >/dev/null 2>&1
-}
+version=$(crate_version "${CRATES[0]}")
+for crate in "${CRATES[@]}"; do
+  v=$(crate_version "$crate")
+  if [ "$v" != "$version" ]; then
+    echo "error: $crate is $v but ${CRATES[0]} is $version — crates are versioned in lockstep." >&2
+    exit 1
+  fi
+done
 
-wait_for_publish() {
-  local crate="$1" version="$2"
-  echo "Waiting for $crate $version to appear on crates.io (CI is publishing)..."
-  for _ in $(seq 1 90); do
-    if is_published "$crate" "$version"; then
-      echo "  $crate $version is live."
-      return 0
-    fi
-    sleep 10
-  done
-  echo "  timed out after 15m waiting for $crate $version" >&2
-  return 1
-}
-
-# --- pre-flight checks -------------------------------------------------------
-
-branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$branch" != "main" ]; then
-  echo "warning: you are on '$branch', not 'main'. Releases are normally cut from main." >&2
-fi
-
-if [ -n "$(git status --porcelain)" ]; then
-  echo "error: working tree is not clean; commit or stash first." >&2
+# In CI the workflow runs on the release's tag; refuse to publish code whose
+# versions don't match the tag that triggered it.
+if [ -n "${GITHUB_REF_NAME:-}" ] && [ "$GITHUB_REF_NAME" != "v$version" ]; then
+  echo "error: release tag '$GITHUB_REF_NAME' does not match crate version '$version' (expected 'v$version')." >&2
   exit 1
 fi
 
-echo "Fetching tags from origin..."
-git fetch --quiet --tags origin
-
-# --- build the plan ----------------------------------------------------------
-
-declare -a to_tag_crate to_tag_version
-echo
-echo "Release plan:"
-for crate in "${CRATES[@]}"; do
-  version=$(crate_version "$crate")
-  tag="$crate-v$version"
-  if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-    echo "  $crate $version — tag $tag already exists locally, skip"
-  elif is_published "$crate" "$version"; then
-    echo "  $crate $version — already on crates.io, skip"
-  else
-    echo "  $crate $version — will tag and push '$tag'"
-    to_tag_crate+=("$crate")
-    to_tag_version+=("$version")
-  fi
-done
-
-if [ "${#to_tag_crate[@]}" -eq 0 ]; then
-  echo
-  echo "Nothing to release. All crate versions are already tagged or published."
-  exit 0
-fi
-
+echo "Publishing ${CRATES[*]} at $version..."
 if [ "$DRY_RUN" = true ]; then
-  echo
-  echo "(dry run — no tags pushed)"
-  exit 0
+  cargo publish --workspace --dry-run
+else
+  cargo publish --workspace
 fi
-
-if [ "$ASSUME_YES" != true ]; then
-  echo
-  read -r -p "Push these tags? [y/N] " reply
-  case "$reply" in
-    y|Y|yes|Yes) ;;
-    *) echo "aborted."; exit 1 ;;
-  esac
-fi
-
-# --- push tags in dependency order -------------------------------------------
-
-for i in "${!to_tag_crate[@]}"; do
-  crate="${to_tag_crate[$i]}"
-  version="${to_tag_version[$i]}"
-  tag="$crate-v$version"
-
-  echo
-  echo "Tagging $tag..."
-  git tag -a "$tag" -m "$crate $version"
-  git push origin "$tag"
-  echo "Pushed $tag — CI will publish $crate $version."
-
-  # logfire-core must be live before the crates that depend on it are tagged.
-  if [ "$crate" = "logfire-core" ]; then
-    wait_for_publish logfire-core "$version"
-  fi
-done
-
-echo
-echo "Done. Watch CI for publish status: https://github.com/pydantic/logfire-rust/actions"


### PR DESCRIPTION
Replaces the per-crate tag-push publish flow with: **publish a GitHub Release → CI tests the tag → `release` environment pauses for maintainer approval → `release.sh` runs in CI and publishes all crates**.

- `main.yml`: drop the `{crate}-v*` tag triggers and the three `cargo publish -p` jobs; add a `release:` `types: [published]` trigger and a single env-gated `release` job with `id-token: write`, authenticating via [`rust-lang/crates-io-auth-action`](https://github.com/rust-lang/crates-io-auth-action) (OIDC trusted publishing — no long-lived `CARGO_REGISTRY_TOKEN` secret).
- `release.sh`: rewritten to run in CI — asserts all crates share one lockstep version and that the release tag is `v{version}`, then `cargo publish --workspace` (cargo ≥1.90 orders `logfire-core` before its dependents and waits for the index). `--dry-run` verified locally: packages all three crates in dependency order.
- `DEVELOPMENT.md`: updated release process.

⚠️ **Do not merge until:**
1. 0.11.0 is published via the existing tag flow (#138 follow-through) — trusted publishing [can only be configured for crates that already exist](https://crates.io/docs/trusted-publishing), and `logfire-core`/`logfire-client` don't yet.
2. Trusted publishing is configured on crates.io for all three crates: repository `pydantic/logfire-rust`, workflow `main.yml`, environment `release` (crate Settings → Trusted Publishing; requires crate ownership).
3. Ideally pydantic/github-iac#28 (required reviewers on the `release` environment) so the approval gate is real.

After cutover, delete the `CARGO_REGISTRY_TOKEN` secret from the `release` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)