### PR TITLE
Send a `logfire-rust/<version>` user agent when exporting via OTLP

### DIFF
--- a/logfire/src/exporters.rs
+++ b/logfire/src/exporters.rs
@@ -16,6 +16,40 @@ use opentelemetry_sdk::{
 
 use crate::{ConfigureError, internal::env::get_optional_env};
 
+/// The `User-Agent` sent with OTLP exports, e.g. `logfire-rust/0.11.0`.
+///
+/// This identifies the Logfire SDK as the sender of the telemetry (as opposed to the resource
+/// attributes, which identify what generated it). The OTLP exporter specification permits
+/// exporters to add their own details to the `User-Agent` header, see
+/// <https://opentelemetry.io/docs/specs/otel/protocol/exporter/#user-agent>.
+#[cfg(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+))]
+const USER_AGENT: &str = concat!("logfire-rust/", env!("CARGO_PKG_VERSION"));
+
+/// Add the Logfire [`USER_AGENT`] to the headers, unless the caller set their own `User-Agent`.
+///
+/// Note that this replaces the `User-Agent` set by `opentelemetry-otlp` for HTTP exports (there is
+/// no way to read it back to append to it); for gRPC exports `tonic` will append its own
+/// `tonic/<version>` to this value.
+#[cfg(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+))]
+fn headers_with_user_agent(headers: Option<HashMap<String, String>>) -> HashMap<String, String> {
+    let mut headers = headers.unwrap_or_default();
+    if !headers
+        .keys()
+        .any(|name| name.eq_ignore_ascii_case("user-agent"))
+    {
+        headers.insert("User-Agent".to_string(), USER_AGENT.to_string());
+    }
+    headers
+}
+
 macro_rules! feature_required {
     ($feature_name:literal, $functionality:expr, $if_enabled:expr) => {{
         #[cfg(feature = $feature_name)]
@@ -74,7 +108,7 @@ pub fn span_exporter(
                     )
                     .connect_lazy(),
                 )
-                .with_metadata(build_metadata_from_headers(headers.as_ref())?)
+                .with_metadata(build_metadata_from_headers(headers)?)
                 .build()?
         }
         #[cfg(feature = "export-http-protobuf")]
@@ -83,7 +117,7 @@ pub fn span_exporter(
             opentelemetry_otlp::SpanExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpBinary)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/traces"))
                 .build()?
         }
@@ -93,7 +127,7 @@ pub fn span_exporter(
             opentelemetry_otlp::SpanExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpJson)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/traces"))
                 .build()?
         }
@@ -163,7 +197,7 @@ pub fn metric_exporter(
                     )
                     .connect_lazy(),
                 )
-                .with_metadata(build_metadata_from_headers(headers.as_ref())?)
+                .with_metadata(build_metadata_from_headers(headers)?)
                 .build()?)
         }
         #[cfg(feature = "export-http-protobuf")]
@@ -173,7 +207,7 @@ pub fn metric_exporter(
                 .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
                 .with_http()
                 .with_protocol(Protocol::HttpBinary)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/metrics"))
                 .build()?)
         }
@@ -184,7 +218,7 @@ pub fn metric_exporter(
                 .with_temporality(opentelemetry_sdk::metrics::Temporality::Delta)
                 .with_http()
                 .with_protocol(Protocol::HttpJson)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/metrics"))
                 .build()?)
         }
@@ -244,7 +278,7 @@ pub fn log_exporter(
                     )
                     .connect_lazy(),
                 )
-                .with_metadata(build_metadata_from_headers(headers.as_ref())?)
+                .with_metadata(build_metadata_from_headers(headers)?)
                 .build()?)
         }
         #[cfg(feature = "export-http-protobuf")]
@@ -253,7 +287,7 @@ pub fn log_exporter(
             Ok(opentelemetry_otlp::LogExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpBinary)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/logs"))
                 .build()?)
         }
@@ -263,7 +297,7 @@ pub fn log_exporter(
             Ok(opentelemetry_otlp::LogExporter::builder()
                 .with_http()
                 .with_protocol(Protocol::HttpJson)
-                .with_headers(headers.unwrap_or_default())
+                .with_headers(headers_with_user_agent(headers))
                 .with_endpoint(format!("{endpoint}/v1/logs"))
                 .build()?)
         }
@@ -286,20 +320,59 @@ pub fn log_exporter(
 
 #[cfg(feature = "export-grpc")]
 fn build_metadata_from_headers(
-    headers: Option<&HashMap<String, String>>,
+    headers: Option<HashMap<String, String>>,
 ) -> Result<tonic::metadata::MetadataMap, ConfigureError> {
-    let Some(headers) = headers else {
-        return Ok(tonic::metadata::MetadataMap::new());
-    };
-
     let mut header_map = http::HeaderMap::new();
-    for (key, value) in headers {
+    for (key, value) in headers_with_user_agent(headers) {
         header_map.insert(
             http::HeaderName::try_from(key).map_err(|e| ConfigureError::Other(e.into()))?,
             http::HeaderValue::try_from(value).map_err(|e| ConfigureError::Other(e.into()))?,
         );
     }
     Ok(tonic::metadata::MetadataMap::from_headers(header_map))
+}
+
+#[cfg(test)]
+#[cfg(any(
+    feature = "export-grpc",
+    feature = "export-http-protobuf",
+    feature = "export-http-json"
+))]
+mod tests {
+    use super::{USER_AGENT, headers_with_user_agent};
+    use std::collections::HashMap;
+
+    #[test]
+    fn user_agent_is_added_to_headers() {
+        assert_eq!(
+            headers_with_user_agent(None),
+            HashMap::from([("User-Agent".to_string(), USER_AGENT.to_string())])
+        );
+
+        let headers = headers_with_user_agent(Some(HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer token".to_string(),
+        )])));
+        assert_eq!(
+            headers,
+            HashMap::from([
+                ("Authorization".to_string(), "Bearer token".to_string()),
+                ("User-Agent".to_string(), USER_AGENT.to_string())
+            ])
+        );
+    }
+
+    #[test]
+    fn user_agent_set_by_caller_is_preserved() {
+        let headers = headers_with_user_agent(Some(HashMap::from([(
+            "user-agent".to_string(),
+            "my-app/1.2.3".to_string(),
+        )])));
+        assert_eq!(
+            headers,
+            HashMap::from([("user-agent".to_string(), "my-app/1.2.3".to_string())])
+        );
+    }
 }
 
 // current default logfire protocol is to export over HTTP in binary format

--- a/logfire/tests/test_grpc_sink.rs
+++ b/logfire/tests/test_grpc_sink.rs
@@ -856,5 +856,26 @@ async fn test_grpc_protobuf_export() {
     "#);
 }
 
+/// The metrics exporter is built by a separate code path to traces and logs, check that it can
+/// be built for gRPC (the user agent is asserted on the wire for traces above).
+#[tokio::test]
+async fn test_grpc_metric_exporter_builds() {
+    let env_guard = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Holding mutex to prevent other threads interacting with env
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc");
+    }
+
+    let exporter = logfire::exporters::metric_exporter("http://localhost:4317", None);
+
+    // SAFETY: As above
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+    }
+    drop(env_guard);
+
+    assert!(exporter.is_ok(), "failed to build gRPC metric exporter");
+}
+
 /// Mutex to avoid concurrent mutation of env vars.
 static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/logfire/tests/test_grpc_sink.rs
+++ b/logfire/tests/test_grpc_sink.rs
@@ -28,11 +28,18 @@ mod test_utils;
 #[derive(Clone)]
 struct MockTraceService {
     captured: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+    captured_user_agents: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockTraceService {
-    fn new(captured: Arc<Mutex<Vec<ExportTraceServiceRequest>>>) -> Self {
-        Self { captured }
+    fn new(
+        captured: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+        captured_user_agents: Arc<Mutex<Vec<String>>>,
+    ) -> Self {
+        Self {
+            captured,
+            captured_user_agents,
+        }
     }
 }
 
@@ -54,6 +61,18 @@ impl TraceService for MockTraceService {
         &self,
         request: Request<ExportTraceServiceRequest>,
     ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        // Capture the user agent for testing
+        {
+            let user_agent = request
+                .metadata()
+                .get("user-agent")
+                .expect("no user-agent sent")
+                .to_str()
+                .expect("user-agent is not valid ASCII")
+                .to_owned();
+            self.captured_user_agents.lock().unwrap().push(user_agent);
+        }
+
         let trace_request = request.into_inner();
 
         // Capture the request for testing
@@ -94,6 +113,7 @@ async fn start_mock_grpc_server() -> (
     String,
     Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
     Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+    Arc<Mutex<Vec<String>>>,
 ) {
     let (ready_tx, ready_rx) = oneshot::channel();
 
@@ -118,7 +138,11 @@ async fn start_mock_grpc_server() -> (
             let captured_logs = Arc::new(Mutex::new(Vec::new()));
             let captured_logs_clone = captured_logs.clone();
 
-            let trace_service = MockTraceService::new(captured_traces_clone);
+            let captured_user_agents = Arc::new(Mutex::new(Vec::new()));
+            let captured_user_agents_clone = captured_user_agents.clone();
+
+            let trace_service =
+                MockTraceService::new(captured_traces_clone, captured_user_agents_clone);
             let logs_service = MockLogsService::new(captured_logs_clone);
 
             tokio::spawn(async move {
@@ -139,7 +163,13 @@ async fn start_mock_grpc_server() -> (
             tonic::client::Grpc::new(channel).ready().await.unwrap();
 
             ready_tx
-                .send((shutdown_tx, addr_str, captured_traces, captured_logs))
+                .send((
+                    shutdown_tx,
+                    addr_str,
+                    captured_traces,
+                    captured_logs,
+                    captured_user_agents,
+                ))
                 .unwrap();
 
             tokio::select! {
@@ -158,7 +188,8 @@ async fn start_mock_grpc_server() -> (
 async fn test_grpc_protobuf_export() {
     use logfire::config::AdvancedOptions;
 
-    let (shutdown_tx, server_addr, captured_traces, captured_logs) = start_mock_grpc_server().await;
+    let (shutdown_tx, server_addr, captured_traces, captured_logs, captured_user_agents) =
+        start_mock_grpc_server().await;
 
     let env_guard = ENV_MUTEX.lock().unwrap();
     // SAFETY: Holding mutex to prevent other threads interacting with env
@@ -196,6 +227,16 @@ async fn test_grpc_protobuf_export() {
         .unwrap();
 
     shutdown_tx.send(()).unwrap();
+
+    // tonic appends its own `tonic/<version>` to the user agent we set
+    let user_agents = std::mem::take(&mut *captured_user_agents.lock().unwrap());
+    assert!(!user_agents.is_empty());
+    for user_agent in user_agents {
+        assert!(
+            user_agent.starts_with(&format!("logfire-rust/{} ", env!("CARGO_PKG_VERSION"))),
+            "unexpected user agent: {user_agent}"
+        );
+    }
 
     let mut trace_requests = std::mem::take(&mut *captured_traces.lock().unwrap());
     let mut log_requests = std::mem::take(&mut *captured_logs.lock().unwrap());
@@ -349,7 +390,7 @@ async fn test_grpc_protobuf_export() {
                                                 AnyValue {
                                                     value: Some(
                                                         IntValue(
-                                                            189,
+                                                            220,
                                                         ),
                                                     ),
                                                 },
@@ -585,7 +626,7 @@ async fn test_grpc_protobuf_export() {
                                                 AnyValue {
                                                     value: Some(
                                                         IntValue(
-                                                            188,
+                                                            219,
                                                         ),
                                                     ),
                                                 },
@@ -711,7 +752,7 @@ async fn test_grpc_protobuf_export() {
                                                 AnyValue {
                                                     value: Some(
                                                         IntValue(
-                                                            190,
+                                                            221,
                                                         ),
                                                     ),
                                                 },

--- a/logfire/tests/test_http_sink.rs
+++ b/logfire/tests/test_http_sink.rs
@@ -1,6 +1,6 @@
 //! Integration tests for HTTP sink with mock server.
 
-use logfire::config::AdvancedOptions;
+use logfire::config::{AdvancedOptions, MetricsOptions};
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -655,6 +655,88 @@ async fn test_http_json_export() {
         ],
     }
     "#);
+}
+
+/// Test that metrics are exported over HTTP with the logfire user agent.
+///
+/// Runs for both HTTP protocols, as they are configured by separate code paths.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_http_metrics_export() {
+    for protocol in ["http/protobuf", "http/json"] {
+        let mock_server = MockServer::start().await;
+
+        mock_server
+            .register(Mock::given(method("POST")).respond_with(ResponseTemplate::new(200)))
+            .await;
+
+        let env_guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: Holding mutex to prevent other thread interacting with env
+        unsafe {
+            std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", protocol);
+        }
+
+        let logfire = configure()
+            .local()
+            .send_to_logfire(true)
+            .with_token("test-token")
+            .with_metrics(Some(MetricsOptions::default()))
+            .with_advanced_options(AdvancedOptions::default().with_base_url(mock_server.uri()))
+            .finish()
+            .unwrap();
+
+        // SAFETY: As above
+        unsafe {
+            std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+        }
+        drop(env_guard);
+
+        logfire.metrics().u64_counter("test_counter").build().add(
+            1,
+            &[opentelemetry::KeyValue::new("test_attribute", "value")],
+        );
+        tokio::task::spawn_blocking(move || logfire.shutdown())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let requests = mock_server.received_requests().await.unwrap();
+        let metrics_requests: Vec<_> = requests
+            .iter()
+            .filter(|request| request.url.path() == "/v1/metrics")
+            .collect();
+        assert!(
+            !metrics_requests.is_empty(),
+            "no metrics exported for {protocol}"
+        );
+        for request in metrics_requests {
+            assert_eq!(
+                request.headers.get("user-agent").expect("no user-agent"),
+                &format!("logfire-rust/{}", env!("CARGO_PKG_VERSION"))
+            );
+        }
+    }
+}
+
+/// An unsupported protocol in the environment is an error.
+#[test]
+fn test_unsupported_protocol() {
+    let env_guard = ENV_MUTEX.lock().unwrap();
+    // SAFETY: Holding mutex to prevent other thread interacting with env
+    unsafe {
+        std::env::set_var("OTEL_EXPORTER_OTLP_PROTOCOL", "carrier-pigeon");
+    }
+
+    let error = logfire::exporters::span_exporter("http://localhost:4318", None)
+        .err()
+        .expect("expected an error for an unsupported protocol");
+
+    // SAFETY: As above
+    unsafe {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_PROTOCOL");
+    }
+    drop(env_guard);
+
+    assert_eq!(error.to_string(), "unsupported protocol: carrier-pigeon");
 }
 
 /// Mutex to avoid concurrent mutation of env vars.

--- a/logfire/tests/test_http_sink.rs
+++ b/logfire/tests/test_http_sink.rs
@@ -61,6 +61,10 @@ async fn test_http_protobuf_export() {
 
     assert_eq!(request.method.as_str(), "POST");
     assert_eq!(request.url.path(), "/v1/traces");
+    assert_eq!(
+        request.headers.get("user-agent").expect("no user-agent"),
+        &format!("logfire-rust/{}", env!("CARGO_PKG_VERSION"))
+    );
     let mut body = ExportTraceServiceRequest::decode(request.body.as_slice())
         .expect("failed to decode trace request");
     make_trace_request_deterministic(&mut body);
@@ -378,6 +382,10 @@ async fn test_http_json_export() {
 
     assert_eq!(request.method.as_str(), "POST");
     assert_eq!(request.url.path(), "/v1/traces");
+    assert_eq!(
+        request.headers.get("user-agent").expect("no user-agent"),
+        &format!("logfire-rust/{}", env!("CARGO_PKG_VERSION"))
+    );
     let mut body: ExportTraceServiceRequest =
         serde_json::from_slice(&request.body).expect("failed to decode trace request");
 
@@ -527,7 +535,7 @@ async fn test_http_json_export() {
                                             AnyValue {
                                                 value: Some(
                                                     IntValue(
-                                                        372,
+                                                        376,
                                                     ),
                                                 ),
                                             },


### PR DESCRIPTION
Identifies the Logfire Rust SDK to the Logfire backend on OTLP export requests, as [discussed on Slack](https://pydantic.slack.com/archives/C05AF4A4WRM/p1784644014528599) and following the same approach as the Python SDK (`logfire/<version>`) and the JS SDK (`logfire-js/<version>`).

The user agent tells us the last mile of the telemetry (who sent it to us), which is complementary to the resource attributes (which say what generated it), and it's what the backend can key retry policy off. The [OTLP exporter spec](https://opentelemetry.io/docs/specs/otel/protocol/exporter/#user-agent) explicitly allows exporters to add their own details to the `User-Agent` header.

Details:
- `User-Agent: logfire-rust/<version>` is added to the headers passed to the OTLP span/metric/log exporters, for all three protocols (`http/protobuf`, `http/json`, `grpc`).
- For gRPC, tonic appends its own token, so the wire value is `logfire-rust/<version> tonic/<version>`.
- For HTTP this replaces `opentelemetry-otlp`'s default `OTel-OTLP-Exporter-Rust/<version>`; the builder API gives no way to read that value back and append to it, so preserving it would mean supplying our own `HttpClient`. Happy to do that as a follow-up if we want both tokens.
- A `User-Agent` supplied by the caller to the public `logfire::exporters::{span_exporter, metric_exporter, log_exporter}` helpers is left untouched.

Tested in the HTTP and gRPC mock-server integration tests, plus unit tests for the header merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jD9BNGcCVUpYWhjYniV6a